### PR TITLE
Fix playing midis

### DIFF
--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -2,19 +2,10 @@
 <html>
 <head>
     <title>Talking score for {{ basic_information['title'] }}</title>
-    <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
-{#    <script type='text/javascript' src='/static/js/midi.js' %}"></script> #}
-{#   <script type='text/javascript' src='http://midijs.net/lib/midi.js'></script> #}
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <!-- midi.js package -->
-{#    <script src="../lib/MIDI.js/js/MIDI/AudioDetect.js" type="text/javascript"></script>#}
-{#    <script src="../lib/MIDI.js/js/MIDI/LoadPlugin.js" type="text/javascript"></script>#}
-{#    <script src="../lib/MIDI.js/js/MIDI/Plugin.js" type="text/javascript"></script>#}
-{#    <script src="../lib/MIDI.js/js/MIDI/Player.js" type="text/javascript"></script>#}
-{#    <script src="../lib/MIDI.js/js/Window/DOMLoader.XMLHttp.js" type="text/javascript"></script>#}
-{#    <!-- extras -->#}
-{#    <script src="../lib/MIDI.js/inc/Base64.js" type="text/javascript"></script>#}
-{#    <script src="../lib/MIDI.js/inc/base64binary.js" type="text/javascript"></script>#}
+    <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
+{#   <!-- extras -->#}
     <style type="text/css">
         body{font-family: Georgia; font-size: 16pt}
     </style>
@@ -28,25 +19,16 @@
 <p>Time signature of {{ preamble['time_signature'] }}, key signature of {{ preamble['key_signature'] }}, tempo of {{ preamble['tempo']|default('no tempo specified') }}</p>
 <p>Music, both hands, a bar at a time, beat by beat</p>
 
-<a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Listen to whole score</a><br/>
+<a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Play entire score</a><br/>
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
-
-<br/><br/><a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Listen to whole score</a><br/>
-
 
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
 
-{#    <a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['both'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, both hands</a>#}
-{#    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['left'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, left hand</a>#}
-{#    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['right'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, right hand</a>#}
-    <a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['both'] }}'); },10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, both hands</a>
-    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['left'] }}'); },10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
-    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['right'] }}'); }, 10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
-{#    <a href="{{ segment.midi_filenames['both'] }}">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, both hands</a>,#}
-{#    <a href="{{ segment.midi_filenames['left'] }}">Listen to bars {{ segment.start_bar }} to {{ segment.end_bar }}, left hand</a>,#}
-{#    <a href="{{ segment.midi_filenames['right'] }}">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, right hand</a>#}
+    <a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['both'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, both hands</a>
+    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['left'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
+    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['right'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
 
     {#  Loop over each bar pulling out the beat-based dictionaries #}
     {% for bar, events_for_beats in segment.events_by_bar_and_beat|dictsort %}
@@ -93,7 +75,6 @@
 {#<script type="text/javascript">#}
 {##}
 {#    window.onload = function () {#}
-{#        console.log("hello") #}
 {#        MIDI.loadPlugin({#}
 {#            soundfontUrl: "../lib/MIDI.js/soundfont/",#}
 {#            instrument: "acoustic_grand_piano",#}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -3,6 +3,8 @@
 <head>
     <title>Talking score for {{ basic_information['title'] }}</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta name="robots" content="noindex" />
+    
     <!-- midi.js package -->
     <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
 {#   <!-- extras -->#}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -2,7 +2,9 @@
 <html>
 <head>
     <title>Talking score for {{ basic_information['title'] }}</title>
-    <script type='text/javascript' src='http://midijs.net/lib/midi.js'></script>
+    <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
+{#    <script type='text/javascript' src='/static/js/midi.js' %}"></script> #}
+{#   <script type='text/javascript' src='http://midijs.net/lib/midi.js'></script> #}
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <!-- midi.js package -->
 {#    <script src="../lib/MIDI.js/js/MIDI/AudioDetect.js" type="text/javascript"></script>#}
@@ -29,6 +31,9 @@
 <a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Listen to whole score</a><br/>
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
 
+<br/><br/><a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Listen to whole score</a><br/>
+
+
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
@@ -36,9 +41,9 @@
 {#    <a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['both'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, both hands</a>#}
 {#    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['left'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, left hand</a>#}
 {#    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['right'] }}'); return false;">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, right hand</a>#}
-    <a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['both'] }}'); },4000); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, both hands</a>
-    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['left'] }}'); },4000); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
-    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['right'] }}'); }, 4000); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
+    <a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['both'] }}'); },10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, both hands</a>
+    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['left'] }}'); },10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
+    <br/><a href="#" onClick="setTimeout(function(){MIDIjs.play('{{ segment.midi_filenames['right'] }}'); }, 10); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
 {#    <a href="{{ segment.midi_filenames['both'] }}">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, both hands</a>,#}
 {#    <a href="{{ segment.midi_filenames['left'] }}">Listen to bars {{ segment.start_bar }} to {{ segment.end_bar }}, left hand</a>,#}
 {#    <a href="{{ segment.midi_filenames['right'] }}">Listen to bars  {{ segment.start_bar }} to {{ segment.end_bar }}, right hand</a>#}
@@ -88,6 +93,7 @@
 {#<script type="text/javascript">#}
 {##}
 {#    window.onload = function () {#}
+{#        console.log("hello") #}
 {#        MIDI.loadPlugin({#}
 {#            soundfontUrl: "../lib/MIDI.js/soundfont/",#}
 {#            instrument: "acoustic_grand_piano",#}

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -401,9 +401,9 @@ class HTMLTalkingScoreFormatter():
             right_hand_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff1'],
                                                                      output_path=output_path)
             if left_hand_midi is not None:
-                midi_filenames['left'] = os.path.join(web_path, os.path.basename(left_hand_midi))
+                midi_filenames['left'] = "/scores2/" + os.path.basename(web_path) + "/" + os.path.basename(left_hand_midi)
             if right_hand_midi is not None:
-                midi_filenames['right'] = os.path.join(web_path, os.path.basename(right_hand_midi))
+                midi_filenames['right'] = "/scores2/" + os.path.basename(web_path) + "/" + os.path.basename(right_hand_midi)
 
             music_segment = {'start_bar':bar_index, 'end_bar': end_bar_index, 'events_by_bar_and_beat': events_by_bar_and_beat, 'midi_filenames': midi_filenames }
             music_segments.append(music_segment)

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -354,7 +354,7 @@ class HTMLTalkingScoreFormatter():
         return template.render({'settings' : self.settings,
                                 'basic_information': self.get_basic_information(),
                                 'preamble': self.get_preamble(),
-                                'full_score': os.path.join(web_path, os.path.basename(self.score.generate_midi_for_part_range(output_path=output_path))),
+                                'full_score': "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(self.score.generate_midi_for_part_range(output_path=output_path)),
                                 'music_segments': self.get_music_segments(output_path,web_path)
                                 })
 
@@ -393,17 +393,22 @@ class HTMLTalkingScoreFormatter():
 
 
             midi_filenames = {
-                'both': os.path.join(web_path, os.path.basename( self.score.generate_midi_for_part_range(bar_index, end_bar_index,output_path=output_path) ) ),
+                #'both': os.path.join(web_path, os.path.basename( self.score.generate_midi_for_part_range(bar_index, end_bar_index,output_path=output_path) ) ),
                 # 'right': os.path.join(web_path, os.path.basename( self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff1'],output_path=output_path) ) ),
             }
+
+            both_hands_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index,
+                                                                     output_path=output_path)
+            midi_filenames['both'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(both_hands_midi)
+                
             left_hand_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff2'],
                                                                      output_path=output_path)
             right_hand_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff1'],
                                                                      output_path=output_path)
             if left_hand_midi is not None:
-                midi_filenames['left'] = "/scores2/" + os.path.basename(web_path) + "/" + os.path.basename(left_hand_midi)
+                midi_filenames['left'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(left_hand_midi)
             if right_hand_midi is not None:
-                midi_filenames['right'] = "/scores2/" + os.path.basename(web_path) + "/" + os.path.basename(right_hand_midi)
+                midi_filenames['right'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(right_hand_midi)
 
             music_segment = {'start_bar':bar_index, 'end_bar': end_bar_index, 'events_by_bar_and_beat': events_by_bar_and_beat, 'midi_filenames': midi_filenames }
             music_segments.append(music_segment)

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -34,7 +34,11 @@ class TSDynamic(TSEvent):
     long_name = None
 
     def __init__(self, long_name=None, short_name=None):
-        self.long_name = long_name
+        if (long_name!=None):
+            self.long_name = long_name.capitalize()
+        else:
+            self.long_name = short_name
+        
         self.short_name = short_name
 
     def render(self, context=None):
@@ -239,7 +243,6 @@ class Music21TalkingScore(TalkingScoreBase):
 
         for element in measure.elements:
             element_type = type(element).__name__
-
             event = None
             hand = ('Left', 'Right')[part_id == 'P1-Staff1']
 
@@ -258,7 +261,7 @@ class Music21TalkingScore(TalkingScoreBase):
                     event.tie = element.tie.type
 
             elif element_type == 'Dynamic':
-                event = TSDynamic(long_name = element.longName.capitalize(), short_name=element.value)
+                event = TSDynamic(long_name = element.longName, short_name=element.value)
                 pitch_index = 0 # Always speak the dynamic first
                 hand = 'Both'
 
@@ -321,7 +324,6 @@ class Music21TalkingScore(TalkingScoreBase):
     #TODO need to make more efficient when working with multiple parts ie more than just the left hand piano part
     #music21 might have a better way of doing this eg using context or something.  If part 0 is included then tempos are already present.
     def insert_tempos(self, stream, offset_start):
-        print('insert tempo - offset start = ' + str(offset_start))
         for mmb in self.score.metronomeMarkBoundaries()[self.last_tempo_inserted_index:]:
             if (mmb[0]>=offset_start+stream.duration.quarterLength): # ignore tempos that start after stream ends
                 return           
@@ -438,7 +440,7 @@ class HTMLTalkingScoreFormatter():
 
 
 if __name__ == '__main__':
-
+    
     # testScoreFilePath = '../talkingscoresapp/static/data/macdowell-to-a-wild-rose.xml'
     testScoreFilePath = '../media/172a28455fa5cfbdaa4eecd5f63a0a2ebaddd92d569980fb402811b9cd5cce4a/MozartPianoSonata.xml'
     # testScoreFilePath = '../talkingscores/talkingscoresapp/static/data/bach-2-part-invention-no-13.xml'

--- a/talkingscores/settings.py
+++ b/talkingscores/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = 'y+-8s4elpz(oge_o42txk#0i5=u9gd0)3q&u+y^+cs#tj9qv1#'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['www.talkingscores.co.uk', '127.0.0.1']
 
 
 # Application definition

--- a/talkingscores/settings.py
+++ b/talkingscores/settings.py
@@ -39,12 +39,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'corsheaders',
     'talkingscoresapp',
 ]
 
 MIDDLEWARE = [
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -55,8 +53,6 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'talkingscores.urls'
-
-
 
 TEMPLATES = [
     {
@@ -128,8 +124,5 @@ STATIC_URL = '/static/'
 
 # Media root
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-#STATIC_ROOT = 'staticfiles'
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = 'staticfiles'
 
-CORS_ORIGIN_ALLOW_ALL = False
-#CORS_ORIGIN_WHITELIST = ('null')

--- a/talkingscores/settings.py
+++ b/talkingscores/settings.py
@@ -39,13 +39,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'talkingscoresapp',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -54,6 +55,8 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'talkingscores.urls'
+
+
 
 TEMPLATES = [
     {
@@ -125,5 +128,8 @@ STATIC_URL = '/static/'
 
 # Media root
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-STATIC_ROOT = 'staticfiles'
+#STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
+CORS_ORIGIN_ALLOW_ALL = False
+#CORS_ORIGIN_WHITELIST = ('null')

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -11,7 +11,10 @@ from urllib.request import url2pathname
 import tempfile
 from talkingscoreslib import Music21TalkingScore, HTMLTalkingScoreFormatter
 
+log_format = "%(levelname)s %(asctime)s - %(message)s"
+logging.basicConfig(filename=os.path.join(*(MEDIA_ROOT, "log1.txt")), format=log_format)
 logger = logging.getLogger(__name__)
+logger.fatal("hello - I'm testing a logger!!!")
 
 def hashfile(afile, hasher, blocksize=65536):
     buf = afile.read(blocksize)
@@ -28,10 +31,10 @@ class TSScoreState(object):
     PROCESSED = "processed"
 
 class TSScore(object):
-
+    
     # I can't seem to find a way of getting the class object in scope at this point to dynamically populate the name
     logger = logging.getLogger("%s.%s" % (__name__, "TSScore"))
-    
+    logger.level = logging.DEBUG
     def __init__(self, id=None, initial_state=TSScoreState.IDLE, url=None, filename=None):
         self._state = initial_state
         self.url   = url
@@ -145,7 +148,6 @@ class TSScore(object):
         try:
             mxml_score = Music21TalkingScore(temporary_file.name)
         except Exception as ex:
-            #logger.exception("Unparsable file: %s" % temporary_file.name)
             logger.exception("Unparsable file: %s" % temporary_file.name + " --- " + str(ex))
             raise ex;
 

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -18,7 +18,6 @@ def hashfile(afile, hasher, blocksize=65536):
     while len(buf) > 0:
         hasher.update(buf)
         buf = afile.read(blocksize)
-    print("hash = %s",hasher.hexdigest())
     return hasher.hexdigest()
 
 class TSScoreState(object):
@@ -33,7 +32,6 @@ class TSScore(object):
     # I can't seem to find a way of getting the class object in scope at this point to dynamically populate the name
     logger = logging.getLogger("%s.%s" % (__name__, "TSScore"))
     
-
     def __init__(self, id=None, initial_state=TSScoreState.IDLE, url=None, filename=None):
         self._state = initial_state
         self.url   = url
@@ -91,7 +89,7 @@ class TSScore(object):
         return self.id
 
     def get_data_file_path(self, root=MEDIA_ROOT, createDirs=True):
-        data_file_path = os.path.join(*(root, self.id, self.filename))
+        data_file_path = os.path.join(*(root, self.id, self.filename)) # removed slashes in directory structure to make files easier to brwose to
         if createDirs:
             dir_to_create = os.path.dirname(data_file_path)
             try:
@@ -148,9 +146,8 @@ class TSScore(object):
             mxml_score = Music21TalkingScore(temporary_file.name)
         except Exception as ex:
             #logger.exception("Unparsable file: %s" % temporary_file.name)
-            logger.exception("Unparsable file: %s" % ex)
+            logger.exception("Unparsable file: %s" % temporary_file.name + " --- " + str(ex))
             raise ex;
-            #return None
 
         score = TSScore(filename=os.path.basename(uploaded_file.name))
         score.store(temporary_file.name, score.filename)

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -18,6 +18,7 @@ def hashfile(afile, hasher, blocksize=65536):
     while len(buf) > 0:
         hasher.update(buf)
         buf = afile.read(blocksize)
+    print("hash = %s",hasher.hexdigest())
     return hasher.hexdigest()
 
 class TSScoreState(object):
@@ -31,6 +32,7 @@ class TSScore(object):
 
     # I can't seem to find a way of getting the class object in scope at this point to dynamically populate the name
     logger = logging.getLogger("%s.%s" % (__name__, "TSScore"))
+    
 
     def __init__(self, id=None, initial_state=TSScoreState.IDLE, url=None, filename=None):
         self._state = initial_state
@@ -89,7 +91,7 @@ class TSScore(object):
         return self.id
 
     def get_data_file_path(self, root=MEDIA_ROOT, createDirs=True):
-        data_file_path = os.path.join(*([root] + list(self.id) + [self.filename]))
+        data_file_path = os.path.join(*(root, self.id, self.filename))
         if createDirs:
             dir_to_create = os.path.dirname(data_file_path)
             try:
@@ -144,9 +146,11 @@ class TSScore(object):
         # Validate this file is loadable
         try:
             mxml_score = Music21TalkingScore(temporary_file.name)
-        except:
-            logger.exception("Unparsable file: %s" % temporary_file.name)
-            return None
+        except Exception as ex:
+            #logger.exception("Unparsable file: %s" % temporary_file.name)
+            logger.exception("Unparsable file: %s" % ex)
+            raise ex;
+            #return None
 
         score = TSScore(filename=os.path.basename(uploaded_file.name))
         score.store(temporary_file.name, score.filename)

--- a/talkingscoresapp/static/css/talkingscores.css
+++ b/talkingscoresapp/static/css/talkingscores.css
@@ -6,6 +6,11 @@ body {
   text-align: center;
 }
 
+.bold-heading {
+	font-size: 21px;
+	font-weight: bold;
+}
+
 .loading {
 	-webkit-animation:spin 2s linear infinite;
 	-moz-animation:spin 2s linear infinite;

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -5,6 +5,19 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+    <!-- google analytics -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-12637058-8"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-12637058-8');
+    </script>
+
+    
     <title>Talking Scores Beta</title
 
             <!-- Bootstrap -->
@@ -12,7 +25,6 @@
 
     <!-- Custom styles for this template -->
     <link href="{% static 'css/talkingscores.css' %}" rel="stylesheet">
-
 </head>
 <body>
 

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -17,10 +17,15 @@
     gtag('config', 'UA-12637058-8');
     </script>
 
-    
-    <title>Talking Scores Beta</title
+    <title>
+        {% block title %}{% endblock %}
+    </title>
 
-            <!-- Bootstrap -->
+    <meta name="description" content="{% block meta-description %}{% endblock %}" />
+    
+    {% block noindex %}{% endblock %}
+
+    <!-- Bootstrap -->
     <link href="{% static 'bootstrap-3.3.2-dist/css/bootstrap.min.css' %}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
@@ -38,13 +43,13 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#">Talking Scores Beta</a>
+            <a class="navbar-brand" href="/">Talking Scores Beta</a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
                 <li class="active"><a href="/">Home</a></li>
-                <li><a href="#about">About</a></li>
-                <li><a href="#contact">Contact</a></li>
+                <li><a href="/change-log">Change Log</a></li>
+                <li><a href="/contact-us">Contact Us</a></li>
             </ul>
         </div>
         <!--/.nav-collapse -->
@@ -57,6 +62,15 @@
     </div>
 </div>
 
+<footer class="navbar-inverse">
+    <div class="container">
+        <div class=”row bottom-rule”>
+            <div class="text-center py-3"><a style="color:white;" href="/privacy-policy">Privacy Policy</a> </div>
+        </div>
+    </div>
+</footer>
+
+
 {#  <main>#}
 {#    <h1>Talking Scores Demo</h1>#}
 {#    <h2></h2>#}
@@ -66,6 +80,14 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 <!-- Include all compiled plugins (below), or include individual files as needed -->
 <script src="{% static 'bootstrap-3.3.2-dist/js/bootstrap.min.js' %}"></script>
+
+<script>
+$(document).ready(function() {
+    $('li.active').removeClass('active');
+    $('a[href="' + location.pathname + '"]').closest('li').addClass('active'); 
+  });
+</script>
+
 {#      </main>#}
 </body>
 </html>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -1,0 +1,56 @@
+{% extends "base_site.html" %}
+{% load staticfiles %}
+
+{% block title %}Change Log - Talking Scores (Beta){% endblock %}
+{% block meta-description %}Overview of updates to Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}
+
+{% block content %}
+    <h1>Talking Scores Beta</h1>
+
+    <div class="col-md-8 col-md-offset-2 text-left">
+
+        <h2>Change Log</h2>
+
+        <p class="lead">This page details various updates made to this project.  The dates represent the approximate date when particular changes were committed in Git.  The actual date that the changes became live on this site will most likely be different.  Progress is gradually being made - so please do retry files that may not have worked before.</p>
+
+        <p class="lead">For more information about specific changes - see the history on <a href="https://github.com/bentimms/talkingscores" target="_blank">Github</a>.</p>
+
+        <p class="lead"><b>Current State</b><br/>
+            This project currently may produce an acceptable output for fairly simple piano music - ie one instrument with 2 staves (treble and bass clef).
+            <ul>
+                <li class="lead">Anything other than a single treble stave and a single bass clef stave causes odd results.</li>
+                <li class="lead">Rests aren't described very well.</li>
+                <li class="lead">Pick-up bars cause odd results.</li>
+            </ul>
+        </p>
+
+        <p class="lead"><b>26th April 2020</b><br/>
+            Added Change Log, Contact Us and Privacy Policy pages with basic title and description for SEO purposes.</p>
+
+        <p class="lead"><b>22nd April 2020</b><br/>
+            Fixed error when long name for Dynamics is not known.</p>
+
+        <p class="lead"><b>19th April 2020</b><br/>
+            Tempos are inserted in midi files for the 2nd stave.  <b>To-do:</b> - insert current tempo at the start of segments.</p>
+    
+        <p class="lead"><b>13th April 2020</b><br/>
+            Added Google Analytics.  Configured robots.txt and noindex so that completed scores are not indexed or tracked.</p>
+    
+        <p class="lead"><b>5th April 2020</b><br/>
+            Fixed CORS error so that midi files are played - ie we can listen to the score - or sections of it.</p>
+
+        <p class="lead"><b>19th January 2020</b><br/>
+            Use 'bars at a time' from Options screen.</p>
+    
+        <p class="lead"><b>28th July 2019</b><br/>
+            Fixed 'unknown duration' for notes smaller than quavers.</p>
+
+        <p class="lead"><b>27th July 2019</b><br/>
+            Fixed key signature in preamble.</p>
+
+        <p class="lead"><b>21st July 2019</b><br/>
+            Fixed pitch ordering within beats and chords.</p>
+    
+    </div>
+
+{% endblock content %}

--- a/talkingscoresapp/templates/contact-us.html
+++ b/talkingscoresapp/templates/contact-us.html
@@ -1,0 +1,23 @@
+{% extends "base_site.html" %}
+{% load staticfiles %}
+
+{% block title %}Contact Us - Talking Scores (Beta){% endblock %}
+{% block meta-description %}We welcome your comments / questions / bug reports - Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}
+
+{% block content %}
+    <h1>Talking Scores Beta</h1>
+
+    <div class="col-md-8 col-md-offset-2 text-left">
+
+        <h2>Contact Us</h2>
+
+        <p class="lead">Please do feel free to contact us with questions / bug reports / feature requests etc - or even just to let us know if you find this project useful!  It is encouraging to hear from users - thank you!</p>
+
+        <p class="lead">Our email address is <a href="mailto:talkingscores@gmail.com">talkingscores@gmail.com</a></p>
+
+        <p class="lead">If you choose to contact us, we will try to reply in a timely manner.  We will most likely contact you again, some time later, when we have addressed your question more fully. <br/>
+            We will not pass your contact details on to anyone else or use them for any other purpose.  For more information - see our <a href="/privacy-policy">Privacy Policy</a>.
+        </p>    
+    </div>
+
+{% endblock content %}

--- a/talkingscoresapp/templates/error.html
+++ b/talkingscoresapp/templates/error.html
@@ -1,6 +1,9 @@
 {% extends "base_site.html" %}
 {% load staticfiles %}
 
+{% block title %}Error producing Talking Score - Talking Scores (Beta){% endblock %}
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block content %}
     <h1>Talking Scores Beta</h1>
 

--- a/talkingscoresapp/templates/index.html
+++ b/talkingscoresapp/templates/index.html
@@ -1,10 +1,20 @@
 {% extends "base_site.html" %}
 {% load staticfiles %}
 
+{% block title %}Talking Scores (Beta) - making musicXML files more accessible{% endblock %}
+{% block meta-description %}Open source project to convert MusicXML files to a spoken description with audio segments - to make sheet music more accessible to print impaired musicians {% endblock %}
+
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <p class="lead">Upload or provide a URL to a MusicXML file.</p>
+    <p class="lead">A Talking Score is a spoken representation of stave notation; often with recordings of the music being described.  They are designed to assist print impaired musicians to use sheet music. </p>
+
+    <p class="lead">Producing a talking score manually can be time consuming, is often not a straightforward process and may require aspects tailored to individual musicians.  This website aims to automatically produce a talking score from a MusicXML file.  </p> 
+        
+    <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  It is a work in progress and has many known issues - and probably many unknown issues too!  Please see the <a href="/change-log">Change Log</a> for latest updates or <a href="/contact-us">contact us</a> with questions / feature requests etc. </p>
+    <hr>
+
+    <h3><b>Upload or provide a URL to a MusicXML file.</b></h3>
 
     <form class="form-horizontal" action="{% url 'index' %}" method="post" enctype="multipart/form-data">
         {% csrf_token %}
@@ -24,7 +34,7 @@
             </div>
         </div>
         <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-6">or</div>
+            <div class="col-sm-offset-3 col-sm-6"><p class="lead">or</p></div>
         </div>
         <div class="form-group">
             <label for="id_url" class="col-sm-3 control-label">URL</label>
@@ -41,12 +51,12 @@
         </div>
     </form>
 
-    <br/>
-    <h3>Example scores</h3>
-
+    <hr>
+    <h3><b>Example scores</b></h3>
+    <p class="lead">These example scores have been produced by this website and should give a good idea of what a Talking Score is.  They might not have been produced by the latest version of the code.</p>
     <ul class="list-unstyled">
         {% for example_score in example_scores %}
-            <li><a href="{% static 'data/' %}{{ example_score }}">{{ example_score }}</a></li>
+            <li class="lead"><a href="{% static 'data/' %}{{ example_score }}">{{ example_score }}</a></li>
         {% endfor %}
     </ul>
     </div>

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -1,6 +1,9 @@
 {% extends "base_site.html" %}
 {% load staticfiles %}
 
+{% block title %}Options - Talking Scores (Beta){% endblock %}
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block content %}
     <h1>Options</h1>
 

--- a/talkingscoresapp/templates/privacy-policy.html
+++ b/talkingscoresapp/templates/privacy-policy.html
@@ -1,0 +1,59 @@
+{% extends "base_site.html" %}
+{% load staticfiles %}
+
+{% block title %}Privacy Policy - Talking Scores (Beta){% endblock %}
+{% block meta-description %}Privacy policy for Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}
+
+{% block content %}
+    <h1>Talking Scores Beta</h1>
+
+    <div class="col-md-8 col-md-offset-2 text-left">
+
+        <h2>Privacy Policy</h2>
+
+        <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  The code running on this site will be fairly close to the code on Github - but there may be some differences due to testing / configuration etc. </p>
+
+        <p class="lead"><b>Communication</b><br/>
+            We welcome comments / suggestions / bug reports etc - it is encouraging to hear from users - thank you.  If you choose to contact us, we will try to reply in a timely manner.  We will most likely contact you again, some time later, when we have addressed the particular issue. <br/>
+            We will not pass your contact details on to anyone else or use them for any other purpose.  <br/>
+            However, we may: 
+            <ul>
+                <li class="lead">Discuss your enquiry (not you, just your enquiry) with other individuals / organisations. </li>
+                <li class="lead">Publish your enquiry (again, not you, just your enquiry), or aspects of it - for example as part of a Frequently Asked Questions page.</li>
+                <li class="lead">Suggest other individuals / organisations / software that might be able to assist with your enquiry.  </li>
+            </ul>
+        </p>
+        
+        <p class="lead"><b>Uploaded files</b><br/>
+            Any files you upload / send us will only be used to produce Talking Scores.  <br/>
+            Your musicxml file (and the talking scores output) will never be shared with any third party.  <br/>
+            However, your musicxml file (or the talking scores output) may be accessed by us - in order to resolve issues or during development / testing / maintenance.   
+        </p>
+
+        <p class="lead"><b>Google Analytics</b><br/>
+            This website uses Google Analytics to give us an idea of how many users the website has / how long they use it for / what pages they view etc. <br/>
+            The HTML output of a Talking Score does not include Google Analytics code - thus the scores are not tracked.  This website uses robots.txt and noindex to inform search engines that completed scores should not be indexed.  
+        </p>
+
+        <p class="lead"><b>Google Search Console</b><br/>
+            This website uses Google Search Console to give us an idea of how it appears in searches on Google.</p>
+            
+        <p class="lead"><b>Cookies</b><br/>
+            This website uses the following cookies:
+            <ul>
+                <li class="lead">'_ga', '_gid', '_gat_gtag_' - used by Google Analytics.</li>
+                <li class="lead">'csrftoken' - helps to prevent Cross Site Request Forgery.</li>
+            </ul>
+        </p>
+
+        <p class="lead"><b>Security</b><br/>
+            We will endeavour to keep this website and its related communications secure.  We do this by considering the tools and processes we use, along with the libraries we build upon and code we write.  <br/>
+            But we cannot guarantee that the files you upload nor your communications with us will not be accessed by others - despite our best efforts.
+        </p>
+        
+        
+        
+        
+    </div>
+
+{% endblock content %}

--- a/talkingscoresapp/templates/processing.html
+++ b/talkingscoresapp/templates/processing.html
@@ -1,6 +1,9 @@
 {% extends "base_site.html" %}
 {% load staticfiles %}
 
+{% block title %}Processing Score - Talking Scores (Beta){% endblock %}
+{% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block content %}
     <h1>Talking Scores Beta</h1>
 

--- a/talkingscoresapp/templates/robots.txt
+++ b/talkingscoresapp/templates/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /score_options/
+Disallow: /process/
+Disallow: /score/
+Disallow: /midis/
+

--- a/talkingscoresapp/urls.py
+++ b/talkingscoresapp/urls.py
@@ -4,6 +4,9 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('change-log', views.change_log, name='change-log'),
+    path('contact-us', views.contact_us, name='contact-us'),
+    path('privacy-policy', views.privacy_policy, name='privacy-policy'),
     path('score/<id>/<filename>', views.score, name='score'),
     path('score_options/<id>/<filename>', views.options, name='options'),
     path('process/<id>/<filename>', views.process, name='process'),

--- a/talkingscoresapp/urls.py
+++ b/talkingscoresapp/urls.py
@@ -1,3 +1,7 @@
+import os
+from django.conf import settings
+from django.conf.urls.static import static
+
 from django.urls import path
 
 from . import views
@@ -8,7 +12,8 @@ urlpatterns = [
     path('score_options/<id>/<filename>', views.options, name='options'),
     path('process/<id>/<filename>', views.process, name='process'),
     path('oops/<id>/<filename>', views.error, name='error'),
+    path('scores2/<id>/<filename>',views.midi, name="midi" ),
 
-]
-# patterns('',
-# ) + static('/scores', document_root=os.path.join(settings.BASE_DIR,settings.STATIC_ROOT, 'data'))
+] + static('/scores', document_root='staticfiles/data') 
+#patterns('',
+#) + static('/scores', document_root=os.path.join(settings.BASE_DIR,settings.STATIC_ROOT, 'data'))

--- a/talkingscoresapp/urls.py
+++ b/talkingscoresapp/urls.py
@@ -1,7 +1,3 @@
-import os
-from django.conf import settings
-from django.conf.urls.static import static
-
 from django.urls import path
 
 from . import views
@@ -12,8 +8,5 @@ urlpatterns = [
     path('score_options/<id>/<filename>', views.options, name='options'),
     path('process/<id>/<filename>', views.process, name='process'),
     path('oops/<id>/<filename>', views.error, name='error'),
-    path('scores2/<id>/<filename>',views.midi, name="midi" ),
-
-] + static('/scores', document_root='staticfiles/data') 
-#patterns('',
-#) + static('/scores', document_root=os.path.join(settings.BASE_DIR,settings.STATIC_ROOT, 'data'))
+    path('midis/<id>/<filename>',views.midi, name="midi" ),
+]

--- a/talkingscoresapp/urls.py
+++ b/talkingscoresapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-
+from django.views.generic.base import TemplateView
 from . import views
 
 urlpatterns = [
@@ -9,4 +9,5 @@ urlpatterns = [
     path('process/<id>/<filename>', views.process, name='process'),
     path('oops/<id>/<filename>', views.error, name='error'),
     path('midis/<id>/<filename>',views.midi, name="midi" ),
+    path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), ),
 ]

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -68,15 +68,6 @@ def score(request, id, filename):
 
 # View for midi files to serve with CORS header
 def midi(request, id, filename):
-    filepath = os.path.join("staticfiles", "data", id, filename)
-    
-    ht = HttpResponse("I might serve a midi file eventually..." + id + " " + filename)
-    #ht.status_code=404
-    #ht['Access-Control-Allow-Origin'] = 'https://www.google.com'
-    #return ht
-        
-    #fr = FileResponse(open("staticfiles/data/a36b9382af7e727001e59dba98183470ac044ccdbb86ac524f06fb4260b9f011/macdowell-to-a-wild-rose2aa_pP1-Staff2_1_1.mid", "rb"))
-    #fr = FileResponse(open("staticfiles/data/t1.mid", "rb"))
     fr = FileResponse(open("staticfiles/data/" + id + "/" + filename, "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
     return fr
@@ -150,8 +141,7 @@ def index(request):
                 err = ex
 
         # If we get this far, there's a problem
-        #form.add_error(None, "Please supply a valid MusicXML file or URL to a MusicXML file... " + err)
-        form.add_error(None, "An error has occurred..." + str(err))
+        form.add_error(None, "An error has occurred...  " + str(err))
     
     else:
         form = MusicXMLSubmissionForm()

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -147,7 +147,6 @@ def index(request):
         form = MusicXMLSubmissionForm()
 
     example_scores = []
-    #for datafile in os.listdir(os.path.join(BASE_DIR, 'talkingscoresapp', 'static', 'data')):
     for datafile in os.listdir(os.path.join(BASE_DIR, 'talkingscoresapp', 'static', 'data')):
         if datafile.endswith('.html'):
             example_scores.append(os.path.basename(datafile))

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -72,7 +72,7 @@ def midi(request, id, filename):
     fr['Access-Control-Allow-Origin'] = '*'
     return fr
 
-# View for the a particular score
+# View for a particular score
 def error(request, id, filename):
     template = loader.get_template('error.html')
 
@@ -89,6 +89,25 @@ def error(request, id, filename):
         form = NotifyEmailForm()
 
     context = {'id': id, 'filename': filename, 'form': form}
+    return HttpResponse(template.render(context, request))
+
+# View for change-log
+def change_log(request):
+    template = loader.get_template('change-log.html')
+    context = {}
+    return HttpResponse(template.render(context, request))
+
+
+# View for contact-us
+def contact_us(request):
+    template = loader.get_template('contact-us.html')
+    context = {}
+    return HttpResponse(template.render(context, request))
+
+# View for privacy-policy
+def privacy_policy(request):
+    template = loader.get_template('privacy-policy.html')
+    context = {}
     return HttpResponse(template.render(context, request))
 
 

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -147,6 +147,7 @@ def index(request):
         form = MusicXMLSubmissionForm()
 
     example_scores = []
+    #for datafile in os.listdir(os.path.join(BASE_DIR, 'talkingscoresapp', 'static', 'data')):
     for datafile in os.listdir(os.path.join(BASE_DIR, 'talkingscoresapp', 'static', 'data')):
         if datafile.endswith('.html'):
             example_scores.append(os.path.basename(datafile))


### PR DESCRIPTION
Midi files are played using midijs.net.  
The corsheaders middleware only seemed to work for django pages and not static files.  
So I created a new pattern in urls.py, which uses a FileResponse and sets Access-Control-Allow-Origin to '*'.  
Perhaps it should have just set it to midijs.net really?

Removed some commented out code relating to hosting midijs files locally.  It is better for hosting / bandwidth if midijs.net hosts their code and .pat files!  I might make backup just in case it ever goes offline!

Also - if there is an exception reading the musicxml file (before the options page is shown) - the exception is shown in the browser - to give the user an idea of what is wrong.  

Later commits:
Previously the tempo changes were only included if score.parts[0] was included (ie both hands or right hand).  Tempo changes are now copied into midi files for the left hand too.

Added google analytics.  Included robots.txt and noindex etc so that finished scores and midi files are not tracked or indexed.