### PR TITLE
Multiple parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .talkingscore-env/
+.talkingscore2-env/
 test_scores/
 media/
 staticfiles/

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -238,10 +238,11 @@ class MidiHandler:
     def insert_tempos(self, stream, offset_start, scale):       
         for mmb in self.score.metronomeMarkBoundaries():
             if (mmb[0]>=offset_start+stream.duration.quarterLength): # ignore tempos that start after stream ends
-                return           
+                return        
             if (mmb[1]>offset_start): # if mmb ends during the segment
                 if (mmb[0])<=offset_start: # starts before segment so insert it at the start of the stream
-                    stream.insert(0, tempo.MetronomeMark( number=mmb[2].number*scale, referent=mmb[2].referent))
+                    #if there is a tempo already in the stream at offset 0 and we insert a different tempo - it seems to happen just before the original tempo so is ignored...
+                    stream.insert(0.001, tempo.MetronomeMark( number=mmb[2].number*scale, referent=mmb[2].referent))
                 else: # starts during segment so insert it part way through the stream
                     stream.insert(mmb[0]-offset_start + self.tempo_shift, tempo.MetronomeMark(number=mmb[2].number*scale, referent=mmb[2].referent))
 

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -3,7 +3,6 @@ __author__ = 'PMarchant'
 import os
 import json
 import math
-import pprint
 import logging, logging.handlers, logging.config
 from tracemalloc import BaseFilter
 from music21 import *
@@ -22,14 +21,14 @@ class MidiHandler:
         bsi = int(self.queryString.get("bsi"))
         self.selected_instruments = []
         while (bsi>1):
-            print ("bsi = " + str(bsi))
+            logger.debug(f"bsi = {bsi}")
             if (bsi&1==True):
                 self.selected_instruments.append(True)
             else:
                 self.selected_instruments.append(False)
             bsi=bsi>>1
         self.selected_instruments.reverse()
-        print(self.selected_instruments)
+        logger.debug(f"selected_instruments = {self.selected_instruments}")
 
         self.all_selected_parts = []
         self.all_unselected_parts = []
@@ -38,8 +37,8 @@ class MidiHandler:
         instrument_index=-1
         prev_instrument=""
         for part_index, part in enumerate(self.score.flat.getInstruments()):
-            print ("part_index = " + str(part_index) )
-            print (part)
+            logger.debug(f"part_index = {part_index}" )
+            logger.debug(part)
             if part.partId!=prev_instrument:
                 instrument_index+=1
                 self.selected_instruement_parts.get(instrument_index)
@@ -56,13 +55,10 @@ class MidiHandler:
 
             prev_instrument=part.partId
 
-        print("all_selected_parts = ")
-        print(self.all_selected_parts)
-        print("all_unselected_parts = ")
-        print(self.all_unselected_parts)
-        print("selected_instruement_parts = ")
-        print(self.selected_instruement_parts)
-
+        logger.debug(f"all_selected_parts = {self.all_selected_parts}")
+        logger.debug(f"all_unselected_parts = {self.all_unselected_parts}")
+        logger.debug(f"selected_instruement_parts = {self.selected_instruement_parts}")
+        
         #play together - all / selected / unselected instruments
         bpi = int(self.queryString.get("bpi"))
         self.play_together_unselected = bpi&1
@@ -74,7 +70,7 @@ class MidiHandler:
         
         
         while (bsi>1):
-            print ("bsi = " + str(bsi))
+            logger.debug (f"bsi = {bsi}")
             if (bsi&1==True):
                 self.selected_instruments.append(True)
             else:
@@ -172,7 +168,7 @@ class MidiHandler:
         if click == 'n':
             return
         
-        print("adding click track")
+        logger.debug("adding click track")
         #todo - use eg instrument.HiHatCymbal() etc after updating music21
         clicktrack = stream.Stream()
         #ins = instrument.Woodblock() # workds d#1 and d#5 ok ish.  beat 1 is too quiet
@@ -200,7 +196,7 @@ class MidiHandler:
                 rest_duration = ts.barDuration.quarterLength - m.duration.quarterLength
                 r = note.Rest()
                 r.duration.quarterLength = rest_duration
-                print("pickup bar - rest_duration = " + str(rest_duration))
+                logger.debug(f"pickup bar - rest_duration = {rest_duration}")
                 for p in self.scoreSegment.parts: #change the bar start offset for all future streams.  Add a rest in all streams (including this one)
                     r = note.Rest()
                     r.duration.quarterLength = rest_duration
@@ -208,7 +204,7 @@ class MidiHandler:
                     for ms in p.getElementsByClass(stream.Measure)[1:]:
                         ms.offset+=rest_duration
                     
-                    print("now added rest to parts - duration = " + str(rest_duration) + " and measure 0 duration = " + str(p.getElementsByClass(stream.Measure)[0].duration.quarterLength))
+                    logger.debug(f"now added rest to parts - duration = {rest_duration} and measure 0 duration = {p.getElementsByClass(stream.Measure)[0].duration.quarterLength}")
                 for p in s.parts: # change the bar start offsets for this stream
                     for ms in p.getElementsByClass(stream.Measure)[1:]:
                         ms.offset+=rest_duration
@@ -264,7 +260,7 @@ class MidiHandler:
             self.midiname+="t"+str(tempo)
         
         self.midiname+=".mid"
-        print("midifilename = " + self.midiname)
+        logger.debug(f"midifilename = {self.midiname}")
         return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         
 
@@ -289,7 +285,7 @@ class MidiHandler:
         toReturn = self.midiname
         midi_filepath = os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         if not os.path.exists(midi_filepath):
-            print("midi file not found - " + self.midiname + " - making it...")
+            logger.debug(f"midi file not found - {self.midiname} - making it...")
             self.make_midi_files()
         
         return toReturn

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -9,6 +9,7 @@ import logging.config
 from tracemalloc import BaseFilter
 from music21 import *
 from talkingscores.settings import BASE_DIR, MEDIA_ROOT, STATIC_ROOT, STATIC_URL
+from talkingscoreslib import Music21TalkingScore
 
 logger = logging.getLogger("TSScore")
 
@@ -235,11 +236,12 @@ class MidiHandler:
             if (mmb[0] >= offset_start+stream.duration.quarterLength):  # ignore tempos that start after stream ends
                 return
             if (mmb[1] > offset_start):  # if mmb ends during the segment
+                tempoNumber = Music21TalkingScore.fix_tempo_number(tempo=mmb[2]).number
                 if (mmb[0]) <= offset_start:  # starts before segment so insert it at the start of the stream
                     # if there is a tempo already in the stream at offset 0 and we insert a different tempo - it seems to happen just before the original tempo so is ignored...
-                    stream.insert(0.001, tempo.MetronomeMark(number=mmb[2].number*scale, referent=mmb[2].referent))
+                    stream.insert(0.001, tempo.MetronomeMark(number=tempoNumber*scale, referent=mmb[2].referent))
                 else:  # starts during segment so insert it part way through the stream
-                    stream.insert(mmb[0]-offset_start + self.tempo_shift, tempo.MetronomeMark(number=mmb[2].number*scale, referent=mmb[2].referent))
+                    stream.insert(mmb[0]-offset_start + self.tempo_shift, tempo.MetronomeMark(number=tempoNumber*scale, referent=mmb[2].referent))
 
     def make_midi_path_from_options(self, sel=None, part=None, ins=None, start=None, end=None, click=None, tempo=None):
         self.midiname = self.filename

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -175,7 +175,9 @@ class MidiHandler:
         print("adding click track")
         #todo - use eg instrument.HiHatCymbal() etc after updating music21
         clicktrack = stream.Stream()
-        ins = instrument.Woodblock() # workds d#1 and d#5 ok ish.  1 is too quiet
+        #ins = instrument.Woodblock() # workds d#1 and d#5 ok ish.  beat 1 is too quiet
+        ins = instrument.Percussion()
+        ins.midiChannel=9 
         clicktrack.insert(0, ins)
         ts:meter.TimeSignature = None
         shift_measure_offset = 0
@@ -188,7 +190,7 @@ class MidiHandler:
             clickmeasure = stream.Measure()
             clickmeasure.mergeAttributes(m)
             clickmeasure.duration= ts.barDuration 
-            clickNote = note.Note('D#1')
+            clickNote = note.Note('D2')
             clickNote.duration = ts.getBeatDuration(0) # specify beat number for complex time signatures...
             clickmeasure.append(clickNote)
             beatpos = ts.getBeatDuration(0).quarterLength
@@ -219,7 +221,7 @@ class MidiHandler:
                 
                  
             for b in range(0, ts.beatCount-1):
-                clickNote = note.Note('D#5')
+                clickNote = note.Note('F#2')
                 clickNote.duration = ts.getBeatDuration(beatpos)
                 beatpos+=clickNote.duration.quarterLength
                 clickmeasure.append(clickNote)

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -17,18 +17,79 @@ class MidiHandler:
         self.folder = folder
         self.filename = filename.replace(".mid", "")
 
+    #get list of selected / unselected instruments from binary of number.  Leftmost value is always 1
+    def get_selected_instruments(self):
+        bsi = int(self.queryString.get("bsi"))
+        self.selected_instruments = []
+        while (bsi>1):
+            print ("bsi = " + str(bsi))
+            if (bsi&1==True):
+                self.selected_instruments.append(True)
+            else:
+                self.selected_instruments.append(False)
+            bsi=bsi>>1
+        self.selected_instruments.reverse()
+        print(self.selected_instruments)
 
-    def make_midi_file(self):
+        self.all_selected_parts = []
+        self.all_unselected_parts = []
+        self.selected_instruement_parts = {} #key = instrument, value = [parts]
+
+        instrument_index=-1
+        prev_instrument=""
+        for part_index, part in enumerate(self.score.flat.getInstruments()):
+            print ("part_index = " + str(part_index) )
+            print (part)
+            if part.partId!=prev_instrument:
+                instrument_index+=1
+                self.selected_instruement_parts.get(instrument_index)
+                
+            if (self.selected_instruments[instrument_index]==True):
+                self.all_selected_parts.append(part_index)
+                if (instrument_index in self.selected_instruement_parts.keys()):
+                    self.selected_instruement_parts[instrument_index].append(part_index)
+                else:
+                    self.selected_instruement_parts[instrument_index] = [part_index]
+            else:
+                self.all_unselected_parts.append(part_index)
+
+            prev_instrument=part.partId
+
+        print("all_selected_parts = ")
+        print(self.all_selected_parts)
+        print("all_unselected_parts = ")
+        print(self.all_unselected_parts)
+        print("selected_instruement_parts = ")
+        print(self.selected_instruement_parts)
+    
+    def make_midi_files(self):
         xml_file_path = os.path.join(*(MEDIA_ROOT, self.folder, self.filename)) #todo - might not be secure 
-        score = converter.parse(xml_file_path+".musicxml") #todo - might be .xml instead of .musicxml
+        self.score = converter.parse(xml_file_path+".musicxml") #todo - might be .xml instead of .musicxml
+        self.get_selected_instruments()
+            
         s = stream.Score(id='temp')
-        s.insert(score.parts[1])
+        
+        if self.queryString.get("start") is None and self.queryString.get("end") is None:
+            #todo - test for pickup bar
+            start = self.score.parts[0].getElementsByClass('Measure')[0].number
+            end = self.score.parts[0].getElementsByClass('Measure')[-1].number
+        else:
+            start = int(self.queryString.get("start"))
+            end = int(self.queryString.get("end"))
+            
+        if (self.queryString.get("part")!=None):
+            s.insert(self.score.parts[int(self.queryString.get("part"))].measures(start,end))
+    
+
         midi_filepath = os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         s.write('midi', midi_filepath)
 
 
     def get_or_make_midi_file(self):
         self.midiname = self.filename
+        if (self.queryString.get("selected")!=None):
+            #todo - just selected parts will be tricky!
+            self.midiname+="selected-"+self.queryString.get("selected")
         if (self.queryString.get("part")!=None):
             self.midiname+="p"+self.queryString.get("part")
         if (self.queryString.get("ins")!=None):
@@ -46,6 +107,6 @@ class MidiHandler:
         
         midi_filepath = os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         if not os.path.exists(midi_filepath):
-            self.make_midi_file()
+            self.make_midi_files()
         
         return self.midiname

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -1,0 +1,51 @@
+__author__ = 'PMarchant'
+
+import os
+import json
+import math
+import pprint
+import logging, logging.handlers, logging.config
+from tracemalloc import BaseFilter
+from music21 import *
+from talkingscores.settings import BASE_DIR, MEDIA_ROOT, STATIC_ROOT, STATIC_URL
+
+logger = logging.getLogger("TSScore")
+
+class MidiHandler:
+    def __init__(self, get, folder, filename):
+        self.queryString = get
+        self.folder = folder
+        self.filename = filename.replace(".mid", "")
+
+
+    def make_midi_file(self):
+        xml_file_path = os.path.join(*(MEDIA_ROOT, self.folder, self.filename)) #todo - might not be secure 
+        score = converter.parse(xml_file_path+".musicxml") #todo - might be .xml instead of .musicxml
+        s = stream.Score(id='temp')
+        s.insert(score.parts[1])
+        midi_filepath = os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
+        s.write('midi', midi_filepath)
+
+
+    def get_or_make_midi_file(self):
+        self.midiname = self.filename
+        if (self.queryString.get("part")!=None):
+            self.midiname+="p"+self.queryString.get("part")
+        if (self.queryString.get("ins")!=None):
+            self.midiname+="i"+self.queryString.get("ins")
+        if (self.queryString.get("start")!=None):
+            self.midiname+="s"+self.queryString.get("start")
+        if (self.queryString.get("end")!=None):
+            self.midiname+="e"+self.queryString.get("end")
+        if (self.queryString.get("click")=="1"):
+            self.midiname+="c"
+        if (self.queryString.get("tempo")!=None):
+            self.midiname+="t"+self.queryString.get("tempo")
+        
+        self.midiname+=".mid"
+        
+        midi_filepath = os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
+        if not os.path.exists(midi_filepath):
+            self.make_midi_file()
+        
+        return self.midiname

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -231,7 +231,7 @@ class MidiHandler:
         
         self.midiname+=".mid"
         print("midifilename = " + self.midiname)
-        return os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
+        return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         
 
     def get_or_make_midi_file(self):
@@ -253,7 +253,7 @@ class MidiHandler:
         
         self.midiname+=".mid"
         toReturn = self.midiname
-        midi_filepath = os.path.join(STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
+        midi_filepath = os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
         if not os.path.exists(midi_filepath):
             print("midi file not found - " + self.midiname + " - making it...")
             self.make_midi_files()

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -260,7 +260,7 @@ class MidiHandler:
 
         self.midiname += ".mid"
         logger.debug(f"midifilename = {self.midiname}")
-        return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % (self.midiname))
+        return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, self.midiname)
 
     def get_or_make_midi_file(self):
         self.midiname = self.filename

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -184,6 +184,9 @@ class MidiHandler:
             else:
                 if (ts == None):
                     ts: meter.TimeSignature = m.previous('TimeSignature')
+                # if the score didn't have a time signature - then just set it to 1/4 to get the first beat of each bar...
+                if (ts == None):
+                    ts = meter.TimeSignature('1/4')
             clickmeasure = stream.Measure()
             clickmeasure.mergeAttributes(m)
             clickmeasure.duration = ts.barDuration

--- a/lib/midiHandler.py
+++ b/lib/midiHandler.py
@@ -3,12 +3,15 @@ __author__ = 'PMarchant'
 import os
 import json
 import math
-import logging, logging.handlers, logging.config
+import logging
+import logging.handlers
+import logging.config
 from tracemalloc import BaseFilter
 from music21 import *
 from talkingscores.settings import BASE_DIR, MEDIA_ROOT, STATIC_ROOT, STATIC_URL
 
 logger = logging.getLogger("TSScore")
+
 
 class MidiHandler:
     def __init__(self, get, folder, filename):
@@ -16,34 +19,34 @@ class MidiHandler:
         self.folder = folder
         self.filename = filename.replace(".mid", "")
 
-    #get list of selected / unselected instruments from binary of number.  Leftmost value is always 1
+    # get list of selected / unselected instruments from binary of number.  Leftmost value is always 1
     def get_selected_instruments(self):
         bsi = int(self.queryString.get("bsi"))
         self.selected_instruments = []
-        while (bsi>1):
+        while (bsi > 1):
             logger.debug(f"bsi = {bsi}")
-            if (bsi&1==True):
+            if (bsi & 1 == True):
                 self.selected_instruments.append(True)
             else:
                 self.selected_instruments.append(False)
-            bsi=bsi>>1
+            bsi = bsi >> 1
         self.selected_instruments.reverse()
         logger.debug(f"selected_instruments = {self.selected_instruments}")
 
         self.all_selected_parts = []
         self.all_unselected_parts = []
-        self.selected_instruement_parts = {} #key = instrument, value = [parts]
-        
-        instrument_index=-1
-        prev_instrument=""
+        self.selected_instruement_parts = {}  # key = instrument, value = [parts]
+
+        instrument_index = -1
+        prev_instrument = ""
         for part_index, part in enumerate(self.score.flat.getInstruments()):
-            logger.debug(f"part_index = {part_index}" )
+            logger.debug(f"part_index = {part_index}")
             logger.debug(part)
-            if part.partId!=prev_instrument:
-                instrument_index+=1
+            if part.partId != prev_instrument:
+                instrument_index += 1
                 self.selected_instruement_parts.get(instrument_index)
-                
-            if (self.selected_instruments[instrument_index]==True):
+
+            if (self.selected_instruments[instrument_index] == True):
                 self.all_selected_parts.append(part_index)
                 if (instrument_index in self.selected_instruement_parts.keys()):
                     self.selected_instruement_parts[instrument_index].append(part_index)
@@ -53,42 +56,40 @@ class MidiHandler:
                 self.all_unselected_parts.append(part_index)
                 self.selected_instruement_parts[instrument_index] = []
 
-            prev_instrument=part.partId
+            prev_instrument = part.partId
 
         logger.debug(f"all_selected_parts = {self.all_selected_parts}")
         logger.debug(f"all_unselected_parts = {self.all_unselected_parts}")
         logger.debug(f"selected_instruement_parts = {self.selected_instruement_parts}")
-        
-        #play together - all / selected / unselected instruments
+
+        # play together - all / selected / unselected instruments
         bpi = int(self.queryString.get("bpi"))
-        self.play_together_unselected = bpi&1
-        bpi=bpi>>1
-        self.play_together_selected = bpi&1
-        bpi=bpi>>1
-        self.play_together_all = bpi&1
-        bpi=bpi>>1
-        
-        
-        while (bsi>1):
-            logger.debug (f"bsi = {bsi}")
-            if (bsi&1==True):
+        self.play_together_unselected = bpi & 1
+        bpi = bpi >> 1
+        self.play_together_selected = bpi & 1
+        bpi = bpi >> 1
+        self.play_together_all = bpi & 1
+        bpi = bpi >> 1
+
+        while (bsi > 1):
+            logger.debug(f"bsi = {bsi}")
+            if (bsi & 1 == True):
                 self.selected_instruments.append(True)
             else:
                 self.selected_instruments.append(False)
-            bsi=bsi>>1
-        
-    
+            bsi = bsi >> 1
+
     def make_midi_files(self):
-        #todo - it is a bit slow for big musicxml files eg chaconne!
-        #todo maybe get the segment of all parts then get parts from that.  
-        xml_file_path = os.path.join(*(MEDIA_ROOT, self.folder, self.filename)) #todo - might not be secure 
-        self.score = converter.parse(xml_file_path+".musicxml") #todo - might be .xml instead of .musicxml
+        # todo - it is a bit slow for big musicxml files eg chaconne!
+        # todo maybe get the segment of all parts then get parts from that.
+        xml_file_path = os.path.join(*(MEDIA_ROOT, self.folder, self.filename))  # todo - might not be secure
+        self.score = converter.parse(xml_file_path+".musicxml")  # todo - might be .xml instead of .musicxml
         self.get_selected_instruments()
-            
+
         s = stream.Score(id='temp')
-        
+
         if self.queryString.get("start") is None and self.queryString.get("end") is None:
-            #todo - test for pickup bar
+            # todo - test for pickup bar
             start = self.score.parts[0].getElementsByClass('Measure')[0].number
             end = self.score.parts[0].getElementsByClass('Measure')[-1].number
 
@@ -97,44 +98,44 @@ class MidiHandler:
             end = int(self.queryString.get("end"))
 
         offset = self.score.parts[0].measure(start).offset
-        
-        #in very rough tests (same bars) using the segment then getting parts from that (instead of original stream) saves 1 or 2 seconds with 2 parts 261 bars, 2,060kb.  
-        #maybe a deep copy would be better?
+
+        # in very rough tests (same bars) using the segment then getting parts from that (instead of original stream) saves 1 or 2 seconds with 2 parts 261 bars, 2,060kb.
+        # maybe a deep copy would be better?
         self.scoreSegment = stream.Score(id='tempSegment')
         for p in self.score.parts:
-            #fix with pickup bar
-            if start==0 and end==0:
-                end=1
+            # fix with pickup bar
+            if start == 0 and end == 0:
+                end = 1
             for m in p.measures(start, end).getElementsByClass('Measure'):
-                #todo - test with repeats
-                m.removeByClass('Repeat') 
-            self.scoreSegment.insert(p.measures(start,end, ))
-            if start==0 and end==1:
-                end=0
-        
+                # todo - test with repeats
+                m.removeByClass('Repeat')
+            self.scoreSegment.insert(p.measures(start, end, ))
+            if start == 0 and end == 1:
+                end = 0
+
         for click in ['n', 'be']:
-            self.tempo_shift = 0 #in a pickup bar - a rest is added to the start of bar 0 to make it a full bar - this offset needs adding to all future tempos 
-            for tempo in [50, 100, 150]: 
-                #play all parts together
+            self.tempo_shift = 0  # in a pickup bar - a rest is added to the start of bar 0 to make it a full bar - this offset needs adding to all future tempos
+            for tempo in [50, 100, 150]:
+                # play all parts together
                 if self.play_together_all:
                     s = stream.Score(id='temp')
                     for p in self.scoreSegment.parts:
-                        s.insert(p.measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature') ))
+                        s.insert(p.measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature')))
                     self.insert_tempos(s, offset, tempo/100)
                     self.insert_click_track(s, click)
-                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="all", tempo=tempo, click=click)) 
+                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="all", tempo=tempo, click=click))
 
-                #play all selected parts together
+                # play all selected parts together
                 if self.play_together_selected:
                     s = stream.Score(id='temp')
                     for part_index, p in enumerate(self.scoreSegment.parts):
                         if part_index in self.all_selected_parts:
-                            s.insert(p.measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature') ))
+                            s.insert(p.measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature')))
                     self.insert_tempos(s, offset, tempo/100)
                     self.insert_click_track(s, click)
-                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="sel", tempo=tempo, click=click)) 
+                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="sel", tempo=tempo, click=click))
 
-                #play all unselected parts together
+                # play all unselected parts together
                 if self.play_together_unselected:
                     s = stream.Score(id='temp')
                     for part_index, p in enumerate(self.scoreSegment.parts):
@@ -142,150 +143,148 @@ class MidiHandler:
                             s.insert(p.measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature')))
                     self.insert_tempos(s, offset, tempo/100)
                     self.insert_click_track(s, click)
-                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="un", tempo=tempo, click=click)) 
+                    s.write('midi', self.make_midi_path_from_options(start=start, end=end, sel="un", tempo=tempo, click=click))
 
-                #each instrument (with 1 or more parts) - if selected
+                # each instrument (with 1 or more parts) - if selected
                 for index, parts_list in enumerate(self.selected_instruement_parts.values()):
-                    if (len(parts_list)>0):
+                    if (len(parts_list) > 0):
                         s = stream.Score(id='temp')
                         for pi in parts_list:
                             s.insert(self.scoreSegment.parts[pi].measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature')))
                         self.insert_tempos(s, offset, tempo/100)
                         self.insert_click_track(s, click)
-                        s.write('midi', self.make_midi_path_from_options(start=start, end=end, ins=index+1, tempo=tempo, click=click)) 
-                        
-                        #now each separate part if the instrument has more than 1 part
-                        if (len(parts_list)>1):
+                        s.write('midi', self.make_midi_path_from_options(start=start, end=end, ins=index+1, tempo=tempo, click=click))
+
+                        # now each separate part if the instrument has more than 1 part
+                        if (len(parts_list) > 1):
                             for pi in parts_list:
                                 s = stream.Score(id='temp')
                                 s.insert(self.scoreSegment.parts[pi].measures(start, end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature')))
                                 self.insert_tempos(s, offset, tempo/100)
                                 self.insert_click_track(s, click)
-                                s.write('midi', self.make_midi_path_from_options(start=start, end=end, part=pi, tempo=tempo, click=click)) 
-                                
+                                s.write('midi', self.make_midi_path_from_options(start=start, end=end, part=pi, tempo=tempo, click=click))
+
     # If there is a pickup bar - add rests to the start - so the click track can start on beat 1
     def insert_click_track(self, s, click):
         if click == 'n':
             return
-        
+
         logger.debug("adding click track")
-        #todo - use eg instrument.HiHatCymbal() etc after updating music21
+        # todo - use eg instrument.HiHatCymbal() etc after updating music21
         clicktrack = stream.Stream()
-        #ins = instrument.Woodblock() # workds d#1 and d#5 ok ish.  beat 1 is too quiet
+        # ins = instrument.Woodblock() # workds d#1 and d#5 ok ish.  beat 1 is too quiet
         ins = instrument.Percussion()
-        ins.midiChannel=9 
+        ins.midiChannel = 9
         clicktrack.insert(0, ins)
-        ts:meter.TimeSignature = None
+        ts: meter.TimeSignature = None
         shift_measure_offset = 0
         for m in s.getElementsByClass(stream.Part)[0].getElementsByClass(stream.Measure):
-            if len(m.getElementsByClass(meter.TimeSignature))>0:
+            if len(m.getElementsByClass(meter.TimeSignature)) > 0:
                 ts = m.getElementsByClass(meter.TimeSignature)[0]
             else:
-                if (ts==None):
-                    ts:meter.TimeSignature = m.previous('TimeSignature')
+                if (ts == None):
+                    ts: meter.TimeSignature = m.previous('TimeSignature')
             clickmeasure = stream.Measure()
             clickmeasure.mergeAttributes(m)
-            clickmeasure.duration= ts.barDuration 
+            clickmeasure.duration = ts.barDuration
             clickNote = note.Note('D2')
-            clickNote.duration = ts.getBeatDuration(0) # specify beat number for complex time signatures...
+            clickNote.duration = ts.getBeatDuration(0)  # specify beat number for complex time signatures...
             clickmeasure.append(clickNote)
             beatpos = ts.getBeatDuration(0).quarterLength
             # if it is a pickup bar then add rests to bar 0 and shift the start offset of the future bars
-            #todo - slight cludge for if the bar doesn't have anything in it (no notes or rests) - possibly should add in the rests at the start of processing
-            if (m.duration.quarterLength < ts.barDuration.quarterLength and len(m.getElementsByClass(['Note', 'Rest']))>0): 
+            # todo - slight cludge for if the bar doesn't have anything in it (no notes or rests) - possibly should add in the rests at the start of processing
+            if (m.duration.quarterLength < ts.barDuration.quarterLength and len(m.getElementsByClass(['Note', 'Rest'])) > 0):
                 rest_duration = ts.barDuration.quarterLength - m.duration.quarterLength
                 r = note.Rest()
                 r.duration.quarterLength = rest_duration
                 logger.debug(f"pickup bar - rest_duration = {rest_duration}")
-                for p in self.scoreSegment.parts: #change the bar start offset for all future streams.  Add a rest in all streams (including this one)
+                for p in self.scoreSegment.parts:  # change the bar start offset for all future streams.  Add a rest in all streams (including this one)
                     r = note.Rest()
                     r.duration.quarterLength = rest_duration
-                    p.getElementsByClass(stream.Measure)[0].insertAndShift(0,r)
+                    p.getElementsByClass(stream.Measure)[0].insertAndShift(0, r)
                     for ms in p.getElementsByClass(stream.Measure)[1:]:
-                        ms.offset+=rest_duration
-                    
+                        ms.offset += rest_duration
+
                     logger.debug(f"now added rest to parts - duration = {rest_duration} and measure 0 duration = {p.getElementsByClass(stream.Measure)[0].duration.quarterLength}")
-                for p in s.parts: # change the bar start offsets for this stream
+                for p in s.parts:  # change the bar start offsets for this stream
                     for ms in p.getElementsByClass(stream.Measure)[1:]:
-                        ms.offset+=rest_duration
-                
+                        ms.offset += rest_duration
+
                 shift_measure_offset = rest_duration
-                #update tempo offsets
+                # update tempo offsets
                 for t in s.getElementsByClass(tempo.MetronomeMark):
-                    if (t.offset>0):
-                        t.offset+=shift_measure_offset
-                    
+                    if (t.offset > 0):
+                        t.offset += shift_measure_offset
+
                 self.tempo_shift = rest_duration
-                
-                 
+
             for b in range(0, ts.beatCount-1):
                 clickNote = note.Note('F#2')
                 clickNote.duration = ts.getBeatDuration(beatpos)
-                beatpos+=clickNote.duration.quarterLength
+                beatpos += clickNote.duration.quarterLength
                 clickmeasure.append(clickNote)
-                
+
             clicktrack.append(clickmeasure)
-         
+
         s.insert(clicktrack)
-        
-    #music21 might have a better way of doing this.  
-    #s.insert(self.score.parts[int(self.queryString.get("part"))].measures(start,end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))) - collect doesn't seem to do anything!
-    #If part 0 is included then tempos are already present.
-    def insert_tempos(self, stream, offset_start, scale):       
+
+    # music21 might have a better way of doing this.
+    # s.insert(self.score.parts[int(self.queryString.get("part"))].measures(start,end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))) - collect doesn't seem to do anything!
+    # If part 0 is included then tempos are already present.
+    def insert_tempos(self, stream, offset_start, scale):
         for mmb in self.score.metronomeMarkBoundaries():
-            if (mmb[0]>=offset_start+stream.duration.quarterLength): # ignore tempos that start after stream ends
-                return        
-            if (mmb[1]>offset_start): # if mmb ends during the segment
-                if (mmb[0])<=offset_start: # starts before segment so insert it at the start of the stream
-                    #if there is a tempo already in the stream at offset 0 and we insert a different tempo - it seems to happen just before the original tempo so is ignored...
-                    stream.insert(0.001, tempo.MetronomeMark( number=mmb[2].number*scale, referent=mmb[2].referent))
-                else: # starts during segment so insert it part way through the stream
+            if (mmb[0] >= offset_start+stream.duration.quarterLength):  # ignore tempos that start after stream ends
+                return
+            if (mmb[1] > offset_start):  # if mmb ends during the segment
+                if (mmb[0]) <= offset_start:  # starts before segment so insert it at the start of the stream
+                    # if there is a tempo already in the stream at offset 0 and we insert a different tempo - it seems to happen just before the original tempo so is ignored...
+                    stream.insert(0.001, tempo.MetronomeMark(number=mmb[2].number*scale, referent=mmb[2].referent))
+                else:  # starts during segment so insert it part way through the stream
                     stream.insert(mmb[0]-offset_start + self.tempo_shift, tempo.MetronomeMark(number=mmb[2].number*scale, referent=mmb[2].referent))
 
     def make_midi_path_from_options(self, sel=None, part=None, ins=None, start=None, end=None, click=None, tempo=None):
         self.midiname = self.filename
-        if (sel!=None):
-            self.midiname+="sel-"+str(sel)
-        if (part!=None):
-            self.midiname+="p"+str(part)
-        if (ins!=None):
-            self.midiname+="i"+str(ins)
-        if (start!=None):
-            self.midiname+="s"+str(start)
-        if (end!=None):
-            self.midiname+="e"+str(end)
-        if (click!=None):
-            self.midiname+="c"+str(click)
-        if (tempo!=None):
-            self.midiname+="t"+str(tempo)
-        
-        self.midiname+=".mid"
+        if (sel != None):
+            self.midiname += "sel-"+str(sel)
+        if (part != None):
+            self.midiname += "p"+str(part)
+        if (ins != None):
+            self.midiname += "i"+str(ins)
+        if (start != None):
+            self.midiname += "s"+str(start)
+        if (end != None):
+            self.midiname += "e"+str(end)
+        if (click != None):
+            self.midiname += "c"+str(click)
+        if (tempo != None):
+            self.midiname += "t"+str(tempo)
+
+        self.midiname += ".mid"
         logger.debug(f"midifilename = {self.midiname}")
-        return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
-        
+        return os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % (self.midiname))
 
     def get_or_make_midi_file(self):
         self.midiname = self.filename
-        if (self.queryString.get("sel")!=None):
-            self.midiname+="sel-"+self.queryString.get("sel") #sel-sel, sel-all, sel-un
-        if (self.queryString.get("part")!=None):
-            self.midiname+="p"+self.queryString.get("part")
-        if (self.queryString.get("ins")!=None):
-            self.midiname+="i"+self.queryString.get("ins")
-        if (self.queryString.get("start")!=None):
-            self.midiname+="s"+self.queryString.get("start")
-        if (self.queryString.get("end")!=None):
-            self.midiname+="e"+self.queryString.get("end")
-        if (self.queryString.get("c")!=None):
-            self.midiname+="c"+self.queryString.get("c")
-        if (self.queryString.get("t")!=None):
-            self.midiname+="t"+self.queryString.get("t")
-        
-        self.midiname+=".mid"
+        if (self.queryString.get("sel") != None):
+            self.midiname += "sel-"+self.queryString.get("sel")  # sel-sel, sel-all, sel-un
+        if (self.queryString.get("part") != None):
+            self.midiname += "p"+self.queryString.get("part")
+        if (self.queryString.get("ins") != None):
+            self.midiname += "i"+self.queryString.get("ins")
+        if (self.queryString.get("start") != None):
+            self.midiname += "s"+self.queryString.get("start")
+        if (self.queryString.get("end") != None):
+            self.midiname += "e"+self.queryString.get("end")
+        if (self.queryString.get("c") != None):
+            self.midiname += "c"+self.queryString.get("c")
+        if (self.queryString.get("t") != None):
+            self.midiname += "t"+self.queryString.get("t")
+
+        self.midiname += ".mid"
         toReturn = self.midiname
-        midi_filepath = os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % ( self.midiname ) )
+        midi_filepath = os.path.join(BASE_DIR, STATIC_ROOT, "data", self.folder, "%s" % (self.midiname))
         if not os.path.exists(midi_filepath):
             logger.debug(f"midi file not found - {self.midiname} - making it...")
             self.make_midi_files()
-        
+
         return toReturn

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -82,7 +82,7 @@ class MusicAnalyser:
         self.analyse_parts = []
         self.repetition_parts = []
         self.summary_parts = []
-        self.repetition_in_contexts = []
+        self.repetition_in_contexts = {} # key = part index
         self.general_summary = ""
 
         analyse_index = 0
@@ -95,7 +95,7 @@ class MusicAnalyser:
                     self.analyse_parts[analyse_index].set_part(self.score.parts[part_index])
                     summary = self.analyse_parts[analyse_index].describe_summary()
                     summary += self.analyse_parts[analyse_index].describe_repetition_summary()
-                    self.repetition_in_contexts.append(self.analyse_parts[analyse_index].describe_repetition_in_context())
+                    self.repetition_in_contexts[part_index] = (self.analyse_parts[analyse_index].describe_repetition_in_context())
                     self.summary_parts.append(summary)
 
                     # self.repetition_parts.append(self.analyse_parts[analyse_index].describe_repetition())
@@ -960,7 +960,7 @@ class AnalysePart:
     # modifies the repetition_in_context dictionary
     def describe_measure_usage_in_context(self, repeated_measures_not_in_groups_dictionary, repeat_what, repetition_in_context):
         for key, ms in repeated_measures_not_in_groups_dictionary.items():
-            temp = "Bar " + str(key) + " is used " + str(len(ms)) + " more times.  "
+            temp = repeat_what + str(key) + " is used " + str(len(ms)) + " more times.  "
             self.insert_or_plus_equals(repetition_in_context, key, temp)
 
             for index, m in enumerate(ms):

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -893,7 +893,8 @@ class AnalysePart:
         temp = self.replace_end_with(temp, ", ", "")
         if temp == "":
             temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
-        repetition += "The repeated sections are " + temp + " measures long.  "
+        if temp != "":
+            repetition += "The repeated sections are " + temp + " measures long.  "
 
         # rhythm or interval
         total_lengths = 0
@@ -904,11 +905,13 @@ class AnalysePart:
         temp = self.replace_end_with(temp, ", ", "")
         if temp == "":
             temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
-        repetition += "The repeated sections of just rhythm / intervals are " + temp + " measures long.  "
+        if temp != "":
+            repetition += "The repeated sections of just rhythm / intervals are " + temp + " measures long.  "
 
-        repetition += "There are " + str(len(self.measure_analyse_indexes_list)) + " unique measures - "
-        repetition += " of these, " + str(len(self.measure_rhythm_analyse_indexes_list)) + " measures have unique rhythm "
-        repetition += " and " + str(len(self.measure_intervals_analyse_indexes_list)) + " measures have unique intervals...  "
+        if (len(self.part.getElementsByClass('Measure')) > 1):
+            repetition += "There are " + str(len(self.measure_analyse_indexes_list)) + " unique measures - "
+            repetition += " of these, " + str(len(self.measure_rhythm_analyse_indexes_list)) + " measures have unique rhythm "
+            repetition += " and " + str(len(self.measure_intervals_analyse_indexes_list)) + " measures have unique intervals...  "
 
         if repetition != "":
             repetition = "<br/>"+repetition.capitalize()

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -940,7 +940,7 @@ class AnalysePart:
             for index, usage in enumerate(group):
                 if index>=1:
                     temp = repeat_what + str(usage[0]) + and_or_through + str(usage[1]) 
-                    temp += " were first used " + str(group[0][0])
+                    temp += " were first used at " + str(group[0][0])
                     if index>=2:
                         temp += " and lately used at " + str(group[index-1][0])
                 else:

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -755,8 +755,8 @@ class AnalysePart:
 
 
     # eg bars 1-4 are repeated all the way through...
-    # todo - eg a few individual bars repeated several times...
-    # todo - eg 1 and 2 bar sections repeated a lot...
+    # eg a few individual bars repeated several times...
+    # eg 1 and 2 bar sections repeated a lot...
     # how many individual bars out of the total - are unique?
     # how many have the same rhythm / intervals ?
     # don't list out every time that every bar is used.
@@ -803,6 +803,58 @@ class AnalysePart:
                 else:
                     break
 
+        # look at number of each repetition length
+        # todo - maybe repetition_lengths should be {[section length, number of usages]}
+        repetition_lengths = {} # full match.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
+        rhythm_interval_repetition_lengths = {} # full match - just rhythm or interval.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
+        total_lengths=0
+        for group in self.measure_groups_list:
+            length = group[0][1]-group[0][0]+1
+            if length in repetition_lengths:
+                repetition_lengths[length] = repetition_lengths[length] + 1
+            else:
+                repetition_lengths[length] = 1
+            
+        for group in self.measure_rhythm_not_full_match_groups_list:
+            length = group[0][1]-group[0][0]+1
+            if length in repetition_lengths:
+                rhythm_interval_repetition_lengths[length] = repetition_lengths[length] + 1
+            else:
+                rhythm_interval_repetition_lengths[length] = 1
+            
+        for group in self.measure_intervals_not_full_match_groups_list:
+            length = group[0][1]-group[0][0]+1
+            if length in repetition_lengths:
+                rhythm_interval_repetition_lengths[length] = repetition_lengths[length] + 1
+            else:
+                rhythm_interval_repetition_lengths[length] = 1
+            
+        repetition_lengths[1] = len(self.repeated_measures_not_in_groups_dictionary)
+        rhythm_interval_repetition_lengths[1] = len(self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary)
+        rhythm_interval_repetition_lengths[1] += len(self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary)
+        print("repetition lengths = " + str(repetition_lengths))
+        print("rhythm and interval repetition lengths = " + str(rhythm_interval_repetition_lengths))
+
+        for k,v in repetition_lengths.items():
+            total_lengths += v
+        sorted_repetition_lengths = sorted(repetition_lengths.items(), reverse=False, key=lambda item: item)
+        temp = self.describe_count_list(sorted_repetition_lengths, total_lengths)
+        temp = self.replace_end_with(temp, ", ", "")
+        if temp=="":
+            temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
+        repetition += "The repeated sections are " + temp + " measures long.  " 
+        
+        #rhythm or interval
+        total_lengths = 0
+        for k,v in rhythm_interval_repetition_lengths.items():
+            total_lengths += v
+        sorted_repetition_lengths = sorted(rhythm_interval_repetition_lengths.items(), reverse=False, key=lambda item: item)
+        temp = self.describe_count_list(sorted_repetition_lengths, total_lengths)
+        temp = self.replace_end_with(temp, ", ", "")
+        if temp=="":
+            temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
+        repetition += "The repeated sections of just rhythm / intervals are " + temp + " measures long.  " 
+        
         repetition += "There are " + str(len(self.measure_analyse_indexes_list)) + " unique measures - "
         repetition += " of these, " + str(len(self.measure_rhythm_analyse_indexes_list)) + " measures have unique rhythm "
         repetition += " and " + str(len(self.measure_intervals_analyse_indexes_list)) + " measures have unique intervals...  "

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -3,7 +3,9 @@ __author__ = 'PMarchant'
 import json
 import math
 import pprint
-import logging, logging.handlers, logging.config
+import logging
+import logging.handlers
+import logging.config
 from music21 import *
 
 logger = logging.getLogger("TSScore")
@@ -23,45 +25,47 @@ A similar technique is applied to Measures to create indexes (or buckets) of Mea
 
 """
 
+
 class AnalyseIndex:
     def __init__(self, ei):
         self.event_index = ei
-        self.event_type = '' # n c r - note / chord / rest
+        self.event_type = ''  # n c r - note / chord / rest
 
-        #[the particular eg chord_interval_index, the occurance of that particular event in eg AnalysePart.chord_pitches_dictionary]
-        self.chord_interval_index = [-1, -1] 
+        # [the particular eg chord_interval_index, the occurance of that particular event in eg AnalysePart.chord_pitches_dictionary]
+        self.chord_interval_index = [-1, -1]
         self.chord_pitches_index = [-1, -1]
         self.chord_name_index = ['', -1]
-        
+
         self.pitch_number_index = [-1, -1]
         self.pitch_name_index = ['', -1]
         self.interval_index = [None, -1]
-        #possibly only needs one rhythm index
+        # possibly only needs one rhythm index
         self.rhythm_note_index = [-1, -1]
         self.rhythm_chord_index = [-1, -1]
         self.rhythm_rest_index = [-1, -1]
-    
+
     def print_info(self):
         print("EventIndex..." + str(self.event_index) + " - type " + self.event_type)
-        if (self.event_type=='n'):
+        if (self.event_type == 'n'):
             print(self.pitch_name_index + self.pitch_number_index + self.interval_index)
-            print ("rhythm " + str(self.rhythm_note_index))
-        elif (self.event_type=='c'):
+            print("rhythm " + str(self.rhythm_note_index))
+        elif (self.event_type == 'c'):
             print(self.chord_pitches_index + self.chord_interval_index + self.chord_name_index)
-            print ("rhythm " + str(self.rhythm_chord_index))
-        elif (self.event_type=='r'):
+            print("rhythm " + str(self.rhythm_chord_index))
+        elif (self.event_type == 'r'):
             print("rhythm " + str(self.rhythm_rest_index))
-        
+
 
 class AnalyseSection:
     def __init__(self):
-        self.analyse_indexes = [] # all the notes etc in the section
-        self.section_start_event_indexes = [] # the event indexes each time this section starts
-        
+        self.analyse_indexes = []  # all the notes etc in the section
+        self.section_start_event_indexes = []  # the event indexes each time this section starts
+
     def print_info(self):
         print("section length = " + str(len(self.analyse_indexes)))
-        #for ai in self.analyse_indexes:
-            #ai.print_info
+        # for ai in self.analyse_indexes:
+        # ai.print_info
+
 
 class MusicAnalyser:
     score = None
@@ -81,11 +85,11 @@ class MusicAnalyser:
         self.repetition_in_contexts = []
         self.general_summary = ""
 
-        analyse_index=0
+        analyse_index = 0
         for ins in ts.part_instruments:
             if ins in ts.selected_instruments:
-                start_part=ts.part_instruments[ins][1]
-                instrument_len=ts.part_instruments[ins][2]
+                start_part = ts.part_instruments[ins][1]
+                instrument_len = ts.part_instruments[ins][2]
                 for part_index in range(start_part, start_part+instrument_len):
                     self.analyse_parts.append(AnalysePart())
                     self.analyse_parts[analyse_index].set_part(self.score.parts[part_index])
@@ -93,62 +97,63 @@ class MusicAnalyser:
                     summary += self.analyse_parts[analyse_index].describe_repetition_summary()
                     self.repetition_in_contexts.append(self.analyse_parts[analyse_index].describe_repetition_in_context())
                     self.summary_parts.append(summary)
-                    
-                    #self.repetition_parts.append(self.analyse_parts[analyse_index].describe_repetition())
+
+                    # self.repetition_parts.append(self.analyse_parts[analyse_index].describe_repetition())
                     analyse_index = analyse_index + 1
-        
+
         self.general_summary += self.describe_general_summary()
 
-    # summarise time / key / tempo changes    
+    # summarise time / key / tempo changes
     def describe_general_summary(self):
         num_measures = len(self.score.parts[0].getElementsByClass('Measure'))
         generalSummary = ""
         generalSummary += "There are " + str(num_measures) + " bars...  "
-        
+
         timesigs = self.score.parts[0].flat.getElementsByClass('TimeSignature')
         generalSummary += self.summarise_key_and_time_changes(timesigs, "time signature")
         keysigs = self.score.parts[0].flat.getElementsByClass('KeySignature')
         generalSummary += self.summarise_key_and_time_changes(keysigs, "key signature")
         tempos = self.score.flat.getElementsByClass('MetronomeMark')
         generalSummary += self.summarise_key_and_time_changes(tempos, "tempo")
-        
-        return generalSummary 
+
+        return generalSummary
 
     # if there are only a couple of changes - list them out with their bar number.
     # if there are more - just say the number
-    def summarise_key_and_time_changes(self, changes_dictionary:dict, changes_name:str):
+    def summarise_key_and_time_changes(self, changes_dictionary: dict, changes_name: str):
         print("summarise key and time changes")
-                    
+
         changes = ""
-        numchanges = len(changes_dictionary) - 1 #the first one isn't a change!
-        if numchanges>4:
+        numchanges = len(changes_dictionary) - 1  # the first one isn't a change!
+        if numchanges > 4:
             changes = "There are " + str(numchanges) + " " + changes_name + " changes..."
-        elif numchanges>0:
+        elif numchanges > 0:
             changes = "The " + changes_name + " changes to "
             index = 0
             for ch in changes_dictionary:
-                if (index>0):
-                    if (changes_name=="time signature"):
+                if (index > 0):
+                    if (changes_name == "time signature"):
                         changes += self.ts.describe_time_signature(ch)
-                    elif (changes_name=="key signature"):
+                    elif (changes_name == "key signature"):
                         changes += self.ts.describe_key_signature(ch)
-                    elif (changes_name=="tempo"):
+                    elif (changes_name == "tempo"):
                         changes += self.ts.describe_tempo(ch)
-                    
-                    changes += " at bar " + str(ch.measureNumber)
-                    if index==numchanges-1:
-                        changes += " and "
-                    elif index<numchanges-1:
-                        changes += ", "
-                index+=1
 
-        if (changes!=""):
-            changes+=".  "
+                    changes += " at bar " + str(ch.measureNumber)
+                    if index == numchanges-1:
+                        changes += " and "
+                    elif index < numchanges-1:
+                        changes += ", "
+                index += 1
+
+        if (changes != ""):
+            changes += ".  "
         return changes
+
 
 class AnalysePart:
 
-    #position based on quarters of the Score
+    # position based on quarters of the Score
     _position_map = {
         0: 'near the start',
         1: 'in the 2nd quarter',
@@ -200,132 +205,132 @@ class AnalysePart:
         0.0625: 'hemi-demi-semi-quavers',
         0.0: 'grace notes',
     }
-    
-    def compare_sections(self, s1:AnalyseSection, s2:AnalyseSection, compare_type): 
+
+    def compare_sections(self, s1: AnalyseSection, s2: AnalyseSection, compare_type):
         to_return = True
-        if (len(s1.analyse_indexes)!=len(s2.analyse_indexes)):
-            to_return=False
+        if (len(s1.analyse_indexes) != len(s2.analyse_indexes)):
+            to_return = False
         else:
             for i in range(len(s1.analyse_indexes)):
-                if (compare_type==0 and self.compare_indexes(s1.analyse_indexes[i], s2.analyse_indexes[i])==False):
-                    to_return=False
+                if (compare_type == 0 and self.compare_indexes(s1.analyse_indexes[i], s2.analyse_indexes[i]) == False):
+                    to_return = False
                     break
-                elif(compare_type==1 and self.compare_indexes_rhythm(s1.analyse_indexes[i], s2.analyse_indexes[i])==False):
-                    to_return=False
+                elif (compare_type == 1 and self.compare_indexes_rhythm(s1.analyse_indexes[i], s2.analyse_indexes[i]) == False):
+                    to_return = False
                     break
-                elif(compare_type==2 and self.compare_indexes_intervals(s1.analyse_indexes[i], s2.analyse_indexes[i])==False):
-                    to_return=False
+                elif (compare_type == 2 and self.compare_indexes_intervals(s1.analyse_indexes[i], s2.analyse_indexes[i]) == False):
+                    to_return = False
                     break
         return to_return
 
-    #one might have a chord or play a note in octaves - and this will say the intervals don't match - because it is expecting single notes...
-    def compare_indexes_intervals(self, ai1:AnalyseIndex, ai2:AnalyseIndex):
+    # one might have a chord or play a note in octaves - and this will say the intervals don't match - because it is expecting single notes...
+    def compare_indexes_intervals(self, ai1: AnalyseIndex, ai2: AnalyseIndex):
         to_return = True
-        if not (ai1.event_type==ai2.event_type):
+        if not (ai1.event_type == ai2.event_type):
             to_return = False
-        elif(ai1.event_type=='n'):
-            if(ai1.interval_index[0]!=ai2.interval_index[0]):
+        elif (ai1.event_type == 'n'):
+            if (ai1.interval_index[0] != ai2.interval_index[0]):
                 to_return = False
-        
-        return to_return
-
-    #rest durations must match.  Chords / single notes are interchangeable - but their durations must match
-    def compare_indexes_rhythm(self, ai1:AnalyseIndex, ai2:AnalyseIndex):
-        to_return = True
-        if (ai1.event_type=='r' and not ai2.event_type=='r'):
-            to_return = False
-        elif ( (ai1.event_type=='n' or ai1.event_type=='c') and ai2.event_type=='r'):
-            to_return = False
-        elif ( (ai1.rhythm_chord_index[0]!=ai2.rhythm_chord_index[0])):
-            to_return = False
-        elif ( (ai1.rhythm_note_index[0]!=ai2.rhythm_note_index[0])):
-            to_return = False
-        elif ( (ai1.rhythm_rest_index[0]!=ai2.rhythm_rest_index[0])):
-            to_return = False
 
         return to_return
-        
-    #Check for the same event type then compare the important attributes of that particular event type
-    def compare_indexes(self, ai1:AnalyseIndex, ai2:AnalyseIndex):
+
+    # rest durations must match.  Chords / single notes are interchangeable - but their durations must match
+    def compare_indexes_rhythm(self, ai1: AnalyseIndex, ai2: AnalyseIndex):
         to_return = True
-        if not (ai1.event_type==ai2.event_type):
+        if (ai1.event_type == 'r' and not ai2.event_type == 'r'):
             to_return = False
-        elif (ai1.event_type=='n'):
-            if (ai1.rhythm_note_index[0]!=ai2.rhythm_note_index[0]) :
+        elif ((ai1.event_type == 'n' or ai1.event_type == 'c') and ai2.event_type == 'r'):
+            to_return = False
+        elif ((ai1.rhythm_chord_index[0] != ai2.rhythm_chord_index[0])):
+            to_return = False
+        elif ((ai1.rhythm_note_index[0] != ai2.rhythm_note_index[0])):
+            to_return = False
+        elif ((ai1.rhythm_rest_index[0] != ai2.rhythm_rest_index[0])):
+            to_return = False
+
+        return to_return
+
+    # Check for the same event type then compare the important attributes of that particular event type
+    def compare_indexes(self, ai1: AnalyseIndex, ai2: AnalyseIndex):
+        to_return = True
+        if not (ai1.event_type == ai2.event_type):
+            to_return = False
+        elif (ai1.event_type == 'n'):
+            if (ai1.rhythm_note_index[0] != ai2.rhythm_note_index[0]):
                 to_return = False
-            if (ai1.pitch_number_index[0]!=ai2.pitch_number_index[0]) :
+            if (ai1.pitch_number_index[0] != ai2.pitch_number_index[0]):
                 to_return = False
-        elif (ai1.event_type=='c'):
-            if (ai1.rhythm_chord_index[0]!=ai2.rhythm_chord_index[0]):
+        elif (ai1.event_type == 'c'):
+            if (ai1.rhythm_chord_index[0] != ai2.rhythm_chord_index[0]):
                 to_return = False
-            if (ai1.chord_pitches_index[0]!=ai2.chord_pitches_index[0]):
+            if (ai1.chord_pitches_index[0] != ai2.chord_pitches_index[0]):
                 to_return = False
-        elif (ai1.event_type=='r'):
-            if (ai1.rhythm_rest_index[0]!=ai2.rhythm_rest_index[0]):
+        elif (ai1.event_type == 'r'):
+            if (ai1.rhythm_rest_index[0] != ai2.rhythm_rest_index[0]):
                 to_return = False
         return to_return
 
     def __init__(self):
-        self.analyse_indexes_list = [] # a list of AnalyseIndex - each unique event}
-        self.analyse_indexes_dictionary = {} # {index of event, [List of event indexes]
-        self.analyse_indexes_all = {} # {event index, [index from analyse_indexes_list, index from analyse_indexes_dictionary]}
-        
-        self.measure_indexes = {} # the event index (from the Part) of the first event of each meausre.  A dictionary instead of a list because there might be a pickup bar
-        
-        self.measure_analyse_indexes_list = [] # each element represents a unique measure as an AnalyseSection - which includes a list of AnalyseIndexes 
-        self.measure_analyse_indexes_dictionary = {} # {index in measure_analyse_indexes_list, [list of measure indexes]}
-        self.measure_analyse_indexes_all = {} # the index of every measure within measure_analyse_indexes_list {meausre_index, [index from measure_analyse_indexes_list, index from measure_analyse_indexes_dictionary]}
-        self.repeated_measures_lists = [] # List of lists of measure indexes where measures match [[1, 3, 6], [2, 4]]
-        self.measure_groups_list = [] #groups of repeated measures [ [[1st group 1st occurance start bar, 1st group 1st occurance last bar], [1st group 2nd occurance start bar, 1st group 2nd occurance last bar]], [[2nd group 1st occurance start bar, 2nd group 1st occurance last bar], [2nd group 2nd occurance start bar, 2nd group 2nd occurance last bar]] ] eg [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ]
-        self.repeated_measures_not_in_groups_dictionary = {} # repeated measures that aren't in a group.  measure index, list of measures it is repeated at
+        self.analyse_indexes_list = []  # a list of AnalyseIndex - each unique event}
+        self.analyse_indexes_dictionary = {}  # {index of event, [List of event indexes]
+        self.analyse_indexes_all = {}  # {event index, [index from analyse_indexes_list, index from analyse_indexes_dictionary]}
 
-        self.measure_rhythm_analyse_indexes_list = [] # each element is an AnalyseSection for a unique measure (containing a list of AnalyseIndex) - but ignoring pitch and intervals etc
-        self.measure_rhythm_analyse_indexes_dictionary = {} # index of each measure occurrence with particular rhythm
-        self.measure_rhythm_analyse_indexes_all = {} # the index of every measure within measure_rhythm_analyse_indexes_list
-        self.repeated_measures_lists_rhythm = [] # where the rhythm matches - but the measure isn't already a full match. [[1, 3, 6], [2, 4]]
-        self.measure_rhythm_not_full_match_groups_list = [] # [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ] ie measures 1 to 4 are used at 9 to 12 and 7 to 8 are used at 15 to 16.
-        self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary = {} # measure index, list of measures it is repeated at
-        
-        self.measure_intervals_analyse_indexes_list = [] # each element is an AnalyseSection for a unique measure (containing a list of AnalyseIndex) - but ignoring rhythm etc
-        self.measure_intervals_analyse_indexes_dictionary = {} # index of each measure occurrence with particular intervals
-        self.measure_intervals_analyse_indexes_all = {} # the index of every measure within measure_intervals_analyse_indexes_list
-        self.repeated_measures_lists_intervals = [] # where the intervals match - but the measure isn't already a full match. [[1, 3, 6], [2, 4]]
-        self.measure_intervals_not_full_match_groups_list = [] # [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ]
-        self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary = {} # measure index, list of measures it is repeated at
-        
-        self.pitch_number_dictionary = {} # midi pitch number, list of event indexes
+        self.measure_indexes = {}  # the event index (from the Part) of the first event of each meausre.  A dictionary instead of a list because there might be a pickup bar
+
+        self.measure_analyse_indexes_list = []  # each element represents a unique measure as an AnalyseSection - which includes a list of AnalyseIndexes
+        self.measure_analyse_indexes_dictionary = {}  # {index in measure_analyse_indexes_list, [list of measure indexes]}
+        self.measure_analyse_indexes_all = {}  # the index of every measure within measure_analyse_indexes_list {meausre_index, [index from measure_analyse_indexes_list, index from measure_analyse_indexes_dictionary]}
+        self.repeated_measures_lists = []  # List of lists of measure indexes where measures match [[1, 3, 6], [2, 4]]
+        self.measure_groups_list = []  # groups of repeated measures [ [[1st group 1st occurance start bar, 1st group 1st occurance last bar], [1st group 2nd occurance start bar, 1st group 2nd occurance last bar]], [[2nd group 1st occurance start bar, 2nd group 1st occurance last bar], [2nd group 2nd occurance start bar, 2nd group 2nd occurance last bar]] ] eg [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ]
+        self.repeated_measures_not_in_groups_dictionary = {}  # repeated measures that aren't in a group.  measure index, list of measures it is repeated at
+
+        self.measure_rhythm_analyse_indexes_list = []  # each element is an AnalyseSection for a unique measure (containing a list of AnalyseIndex) - but ignoring pitch and intervals etc
+        self.measure_rhythm_analyse_indexes_dictionary = {}  # index of each measure occurrence with particular rhythm
+        self.measure_rhythm_analyse_indexes_all = {}  # the index of every measure within measure_rhythm_analyse_indexes_list
+        self.repeated_measures_lists_rhythm = []  # where the rhythm matches - but the measure isn't already a full match. [[1, 3, 6], [2, 4]]
+        self.measure_rhythm_not_full_match_groups_list = []  # [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ] ie measures 1 to 4 are used at 9 to 12 and 7 to 8 are used at 15 to 16.
+        self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary = {}  # measure index, list of measures it is repeated at
+
+        self.measure_intervals_analyse_indexes_list = []  # each element is an AnalyseSection for a unique measure (containing a list of AnalyseIndex) - but ignoring rhythm etc
+        self.measure_intervals_analyse_indexes_dictionary = {}  # index of each measure occurrence with particular intervals
+        self.measure_intervals_analyse_indexes_all = {}  # the index of every measure within measure_intervals_analyse_indexes_list
+        self.repeated_measures_lists_intervals = []  # where the intervals match - but the measure isn't already a full match. [[1, 3, 6], [2, 4]]
+        self.measure_intervals_not_full_match_groups_list = []  # [ [[1, 4], [9, 12]], [[7, 8], [15, 16]] ]
+        self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary = {}  # measure index, list of measures it is repeated at
+
+        self.pitch_number_dictionary = {}  # midi pitch number, list of event indexes
         for i in range(128):
             self.pitch_number_dictionary[i] = []
-        self.pitch_name_dictionary = {} # pitch name (without octave), [event indexes]
-        self.interval_dictionary = {} # interval (in semitones +x / -x / 0), [event indexes]
-        self.rhythm_note_dictionary = {} # duration (in fractions of quarter notes) of single notes, [event indexes]
-        self.rhythm_rest_dictionary = {} # duration (in fractions of quarter notes) of rests, [event indexes]
-        self.rhythm_chord_dictionary = {} # duration (in fractions of quarter notes) of chords, [event indexes]
-        
-        self.count_accidentals_in_measures = {} # {measure number, number of accidentals in it}
-        self.count_gracenotes_in_measures = {} # {measure number, number of accidentals in it}
-        self.count_rests_in_measures = {} # {measure number, number of accidentals in it}
+        self.pitch_name_dictionary = {}  # pitch name (without octave), [event indexes]
+        self.interval_dictionary = {}  # interval (in semitones +x / -x / 0), [event indexes]
+        self.rhythm_note_dictionary = {}  # duration (in fractions of quarter notes) of single notes, [event indexes]
+        self.rhythm_rest_dictionary = {}  # duration (in fractions of quarter notes) of rests, [event indexes]
+        self.rhythm_chord_dictionary = {}  # duration (in fractions of quarter notes) of chords, [event indexes]
 
-        self.chord_pitches_list = [] # each unique chord based on pitches (midi number)
-        self.chord_pitches_dictionary = {} # index in chord_pitches_list, [event indexes]
-        self.chord_intervals_list = [] # each unique chord based on the intervals in it
-        self.chord_intervals_dictionary = {} # index in chord_intervals_list, [event indexes]
-        self.chord_common_name_dictionary = {} #chord name, [event indexes]
+        self.count_accidentals_in_measures = {}  # {measure number, number of accidentals in it}
+        self.count_gracenotes_in_measures = {}  # {measure number, number of accidentals in it}
+        self.count_rests_in_measures = {}  # {measure number, number of accidentals in it}
 
-        self.count_pitches = [] # [[pitch number, count]] ordered by descending count. produced by count_dictionary()
-        self.count_pitch_names = [] # [[pitch name, count]] ordered by descending count. produced by count_dictionary()
-        self.count_intervals = [] # [[interval +x / -x / 0, count]] ordered by descending count. produced by count_dictionary()
-        self.count_intervals_abs = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0] #count of intervals (unison to 2 octaves) - ignore ascending or descending
-        self.count_chord_pitches = [] # [[key from chord_pitches_dictionary, count]] ordered by descending count. produced by count_dictionary()
-        self.count_chord_intervals = [] # [[key from chord_intervals_dictionary, count]] ordered by descending count. produced by count_dictionary()
-        self.count_chord_common_names = [] # [[chord common name, count]] ordered by descending count. produced by count_dictionary()
-        self.count_notes_in_chords = {2:0, 3:0, 4:0, 5:0, 6:0, 7:0, 8:0, 9:0, 10:0} # {number of notes in chord, number of occurances}
-        self.count_rhythm_note = [] # [[duration of individual note, count]] ordered by descending count. produced by count_dictionary()
-        self.count_rhythm_rest = [] # [[duration of rest, count]] ordered by descending count. produced by count_dictionary()
-        self.count_rhythm_chord = [] # [[duration of chord, count]] ordered by descending count. produced by count_dictionary()
+        self.chord_pitches_list = []  # each unique chord based on pitches (midi number)
+        self.chord_pitches_dictionary = {}  # index in chord_pitches_list, [event indexes]
+        self.chord_intervals_list = []  # each unique chord based on the intervals in it
+        self.chord_intervals_dictionary = {}  # index in chord_intervals_list, [event indexes]
+        self.chord_common_name_dictionary = {}  # chord name, [event indexes]
+
+        self.count_pitches = []  # [[pitch number, count]] ordered by descending count. produced by count_dictionary()
+        self.count_pitch_names = []  # [[pitch name, count]] ordered by descending count. produced by count_dictionary()
+        self.count_intervals = []  # [[interval +x / -x / 0, count]] ordered by descending count. produced by count_dictionary()
+        self.count_intervals_abs = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  # count of intervals (unison to 2 octaves) - ignore ascending or descending
+        self.count_chord_pitches = []  # [[key from chord_pitches_dictionary, count]] ordered by descending count. produced by count_dictionary()
+        self.count_chord_intervals = []  # [[key from chord_intervals_dictionary, count]] ordered by descending count. produced by count_dictionary()
+        self.count_chord_common_names = []  # [[chord common name, count]] ordered by descending count. produced by count_dictionary()
+        self.count_notes_in_chords = {2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0}  # {number of notes in chord, number of occurances}
+        self.count_rhythm_note = []  # [[duration of individual note, count]] ordered by descending count. produced by count_dictionary()
+        self.count_rhythm_rest = []  # [[duration of rest, count]] ordered by descending count. produced by count_dictionary()
+        self.count_rhythm_chord = []  # [[duration of chord, count]] ordered by descending count. produced by count_dictionary()
 
         # used for calculating percentages etc
-        self.total_note_duration = 0 
+        self.total_note_duration = 0
         self.note_count = 0
         self.interval_count = 0
         self.interval_ascending_count = 0
@@ -335,22 +340,22 @@ class AnalysePart:
         self.rest_count = 0
         self.total_chord_duration = 0
         self.chord_count = 0
-        self.accidental_count = 0 # displayed accidentals ie not in the key signature
+        self.accidental_count = 0  # displayed accidentals ie not in the key signature
         self.gracenote_count = 0
-        self.possible_accidental_count = 0 # each note - on its own or part of a chord
-        
+        self.possible_accidental_count = 0  # each note - on its own or part of a chord
+
         self.part = None
 
-    #if a section doesn't contain any consecutive notes - then it doesn't contain any intervals...
-    #since all the interval indexes default to None so we check this first otherwise compare_sections will think it is a match for intervals!
-    def does_section_contain_intervals(self, section:AnalyseSection):
+    # if a section doesn't contain any consecutive notes - then it doesn't contain any intervals...
+    # since all the interval indexes default to None so we check this first otherwise compare_sections will think it is a match for intervals!
+    def does_section_contain_intervals(self, section: AnalyseSection):
         for ai in section.analyse_indexes:
-            if (ai.interval_index[0]!=None):
+            if (ai.interval_index[0] != None):
                 return True
         return False
 
-    #compare_type - 0 = all, 1=rhythm, 2=intervals
-    def find_section(self, section_to_find:AnalyseSection, sections_to_search, compare_type):
+    # compare_type - 0 = all, 1=rhythm, 2=intervals
+    def find_section(self, section_to_find: AnalyseSection, sections_to_search, compare_type):
         i = 0
         for s in sections_to_search:
             if self.compare_sections(s, section_to_find, compare_type):
@@ -368,23 +373,23 @@ class AnalysePart:
 
     # find chord (based on midi pitches) in self.chord_pitches_list
     def find_chord(self, chord):
-        chord_index=0
+        chord_index = 0
         find = sorted(p.midi for p in chord.pitches)
         for c in self.chord_pitches_list:
-            if c==find:
+            if c == find:
                 return chord_index
             chord_index += 1
         return -1
-    
+
     # find chord (based on intervals) in self.chord_intervals_list
     def find_chord_intervals(self, chord_intervals):
-        chord_index=0
+        chord_index = 0
         for c in self.chord_intervals_list:
-            if c==chord_intervals:
+            if c == chord_intervals:
                 return chord_index
             chord_index += 1
         return -1
-    
+
     # return a sorted list of ascending intervals from lowest note - don't include 0
     # major triad = [4, 7]
     def make_chord_intervals(self, chord):
@@ -392,46 +397,46 @@ class AnalysePart:
         pitches = sorted(p.midi for p in chord.pitches[1:])
         intervals = [p-p1 for p in pitches]
         return intervals
-    
+
     # measure_index = when is this measure next used
     # from_all eg self.measure_analyse_indexes_all = {} # the index of every measure within measure_analyse_indexes_list {meausre_index, [index from measure_analyse_indexes_list, index from measure_analyse_indexes_dictionary]}
-    # from_indexes_dictionary eg self.measure_analyse_indexes_dictionary = {} # {index in measure_analyse_indexes_list, [list of measure indexes]}   
+    # from_indexes_dictionary eg self.measure_analyse_indexes_dictionary = {} # {index in measure_analyse_indexes_list, [list of measure indexes]}
     # returns the measure number or -1 if not found.
     def when_is_measure_next_used(self, measure_index, from_all, from_indexes_dictionary):
         mia = from_indexes_dictionary[from_all[measure_index][0]]
-        if len(mia)-1>from_all[measure_index][1]:
-            return mia[from_all[measure_index][1]+1] 
+        if len(mia)-1 > from_all[measure_index][1]:
+            return mia[from_all[measure_index][1]+1]
         else:
             return -1
 
-    #from_list = list of lists where measure (eg rhythm) is repeated - eg [[1, 3, 6], [2, 4]] ie measure 1 is used at 3 and 6.  Measure 2 is used at 4.
-    #basically depending which list is passed in - see if two measures have the same rhythm / intervals etc
+    # from_list = list of lists where measure (eg rhythm) is repeated - eg [[1, 3, 6], [2, 4]] ie measure 1 is used at 3 and 6.  Measure 2 is used at 4.
+    # basically depending which list is passed in - see if two measures have the same rhythm / intervals etc
     def are_measures_in(self, group_list, measure_index1, measure_index2):
         for group in group_list:
             if measure_index1 in group and measure_index2 in group:
                 return True
-        return False 
-        
-    # do two measures have matching pitch / rhythm / intervals etc    
+        return False
+
+    # do two measures have matching pitch / rhythm / intervals etc
     def is_measure_used_at(self, indexes_all, current_measure_index, check_measure_index):
-        #todo - these two checks are in case a measure doesn't have anything in then won't be added as a key to the dictionary...
+        # todo - these two checks are in case a measure doesn't have anything in then won't be added as a key to the dictionary...
         if not check_measure_index in indexes_all:
             return False
         elif not current_measure_index in indexes_all:
-            return False 
-        else:    
-            if (indexes_all[current_measure_index][0]==indexes_all[check_measure_index][0]):
+            return False
+        else:
+            if (indexes_all[current_measure_index][0] == indexes_all[check_measure_index][0]):
                 return True
             else:
                 return False
-    
-    #mg = start and end measure in group [1,4]
-    #mg_lists = list of lists of measure groups eg [ [[1,4],[5,8]], [[9,10],[11,12]] ]
+
+    # mg = start and end measure in group [1,4]
+    # mg_lists = list of lists of measure groups eg [ [[1,4],[5,8]], [[9,10],[11,12]] ]
     def find_measure_group(self, mg, mg_lists):
         mg_index = 0
         for measure_groups in mg_lists:
             for group in measure_groups:
-                if mg==group:
+                if mg == group:
                     return mg_index
             mg_index += 1
         return -1
@@ -443,12 +448,12 @@ class AnalysePart:
     def calculate_repeated_measures_lists(self, from_measure_dictionary, not_full_match):
         to_list = []
         for measure_indexes in from_measure_dictionary.values():
-            if len(measure_indexes)>1: # this measure is used more than once
-                measures=[]
+            if len(measure_indexes) > 1:  # this measure is used more than once
+                measures = []
                 for measure_index in measure_indexes:
-                    if (not_full_match==False or len(self.measure_analyse_indexes_dictionary[self.measure_analyse_indexes_all[measure_index][0]])==1):
-                        measures.append(measure_index)               
-                if len(measures)>1:
+                    if (not_full_match == False or len(self.measure_analyse_indexes_dictionary[self.measure_analyse_indexes_all[measure_index][0]]) == 1):
+                        measures.append(measure_index)
+                if len(measures) > 1:
                     to_list.append(measures)
         return to_list
 
@@ -456,13 +461,13 @@ class AnalysePart:
     def calculate_repeated_measures_not_in_groups(self, measures_list, groups_list):
         output_dictionary = {}
         for measure_indexes in measures_list:
-            if len(measure_indexes)>1: # the measure is used more than once
-                measures=[]
+            if len(measure_indexes) > 1:  # the measure is used more than once
+                measures = []
                 for measure_index in measure_indexes:
                     if not self.in_measure_groups(measure_index, groups_list):
                         measures.append(measure_index)
-                
-                if len(measures)>1:
+
+                if len(measures) > 1:
                     output_dictionary[measures[0]] = measures[1:]
         return output_dictionary
 
@@ -470,7 +475,7 @@ class AnalysePart:
     def in_measure_groups(self, measure_index, groups_list):
         for mgl in groups_list:
             for mg in mgl:
-                if measure_index>=mg[0] and measure_index<=mg[1]:
+                if measure_index >= mg[0] and measure_index <= mg[1]:
                     return True
         return False
 
@@ -478,95 +483,95 @@ class AnalysePart:
     def are_measures_in_same_group(self, measure_index1, measure_index2, groups_list):
         for mgl in groups_list:
             for mg in mgl:
-                if measure_index1>=mg[0] and measure_index1<=mg[1] and measure_index2>=mg[0] and measure_index2<=mg[1]:
+                if measure_index1 >= mg[0] and measure_index1 <= mg[1] and measure_index2 >= mg[0] and measure_index2 <= mg[1]:
                     return True
         return False
 
-    #from_indexes_all eg self.measure_analyse_indexes_all - {meausre_index, [index from measure_analyse_indexes_list, index from measure_analyse_indexes_dictionary]}
-    #from_indexes_dictionary eg measure_analyse_indexes_dictionary - {index in measure_analyse_indexes_list, [list of measure indexes]}
-    #returns eg self.measure_groups_list = [] #groups of repeated measures [ [[1, 4], [9, 12]], [[5, 6], [7,8]] ] 
-    #TODO - improve so it the first measure in the group can be used more than once
+    # from_indexes_all eg self.measure_analyse_indexes_all - {meausre_index, [index from measure_analyse_indexes_list, index from measure_analyse_indexes_dictionary]}
+    # from_indexes_dictionary eg measure_analyse_indexes_dictionary - {index in measure_analyse_indexes_list, [list of measure indexes]}
+    # returns eg self.measure_groups_list = [] #groups of repeated measures [ [[1, 4], [9, 12]], [[5, 6], [7,8]] ]
+    # TODO - improve so it the first measure in the group can be used more than once
     def calculate_measure_groups(self, from_indexes_all, from_indexes_dictionary):
         to_list = []
         next_used_at = 1
         group_size = 1
         gap = 1
-        skip=0
+        skip = 0
         for look_at_measure in from_indexes_all:
-            #if measures 1 to 4 are repeated then don't mention that 2 to 4 and 3 to 4 are also repeated!
-            if (skip>0):
-                skip-=1
+            # if measures 1 to 4 are repeated then don't mention that 2 to 4 and 3 to 4 are also repeated!
+            if (skip > 0):
+                skip -= 1
                 continue
 
-            #see when the current measure is next used
+            # see when the current measure is next used
             next_used_at = self.when_is_measure_next_used(look_at_measure, from_indexes_all, from_indexes_dictionary)
-            if next_used_at>-1:
+            if next_used_at > -1:
                 gap = next_used_at - look_at_measure
-                #eg if 4 is used at 6, check if 5 is used at 7
-                if gap>1:
-                    group_size=1
-                    while (group_size<gap and (look_at_measure + group_size + gap) in from_indexes_all) and (self.is_measure_used_at(from_indexes_all, look_at_measure + group_size, look_at_measure + group_size + gap)):
-                        group_size+=1
-                    
-                    group_size-=1
+                # eg if 4 is used at 6, check if 5 is used at 7
+                if gap > 1:
+                    group_size = 1
+                    while (group_size < gap and (look_at_measure + group_size + gap) in from_indexes_all) and (self.is_measure_used_at(from_indexes_all, look_at_measure + group_size, look_at_measure + group_size + gap)):
+                        group_size += 1
 
-                    #if a group of bars is actually repeated    
-                    if (group_size>0):
+                    group_size -= 1
+
+                    # if a group of bars is actually repeated
+                    if (group_size > 0):
                         measure_group = [look_at_measure, look_at_measure + group_size]
                         measure_group_index = self.find_measure_group(measure_group, to_list)
-                        if (measure_group_index==-1): #ie need to add 1st and 2nd occurance.  When you come to 2nd and 3rd occurance - the 2nd occurance will already have been added.  Does it this way to avoid not adding the final occurance
+                        if (measure_group_index == -1):  # ie need to add 1st and 2nd occurance.  When you come to 2nd and 3rd occurance - the 2nd occurance will already have been added.  Does it this way to avoid not adding the final occurance
                             to_list.append([measure_group])
                             to_list[len(to_list)-1].append([look_at_measure + gap, look_at_measure + gap + group_size])
                         else:
                             to_list[measure_group_index].append([look_at_measure + gap, look_at_measure + gap + group_size])
-                    
-                        skip=group_size #not great as it overlooks possible smaller gruops within large groups eg it will find 1 t 8 being used at 9 to 16 but miss 1 to 4 being used at 17 to 20.
+
+                        skip = group_size  # not great as it overlooks possible smaller gruops within large groups eg it will find 1 t 8 being used at 9 to 16 but miss 1 to 4 being used at 17 to 20.
         return to_list
 
     def describe_repetition_percentage(self, percent):
-        if percent>99:
+        if percent > 99:
             return "all"
-        elif percent>85:
+        elif percent > 85:
             return "almost all"
-        elif percent>75:
+        elif percent > 75:
             return "over three quarters"
-        elif percent>50:
+        elif percent > 50:
             return "over half"
-        elif percent>33:
+        elif percent > 33:
             return "over a thrid"
         else:
             return ""
 
-    #return a list with commas plus an and in the right place
-    #eg [1,4,6] = "1, 4 and 6"
+    # return a list with commas plus an and in the right place
+    # eg [1,4,6] = "1, 4 and 6"
     def comma_and_list(self, l):
         output = ""
         for index, v in enumerate(l):
-            if index==len(l)-1 and index>0:
-                    output += " and "
-            elif index<len(l)-1 and index>0:
-                output += ", "  
+            if index == len(l)-1 and index > 0:
+                output += " and "
+            elif index < len(l)-1 and index > 0:
+                output += ", "
             output += str(v)
         return output
 
-
     # count_in_measures = a dictionary {measure index, number of eg rests accidentals in that measure}
-    # total = the total number of rests / accidentals 
+    # total = the total number of rests / accidentals
+
     def describe_distribution(self, count_in_measures, total):
         distribution = ""
 
         # make a dictionary of percentages for each measure then sort by percent descending
         measure_percents = {}
         for k, c in count_in_measures.items():
-            if c>0:
-                measure_percents[k] = (c/total)*100        
+            if c > 0:
+                measure_percents[k] = (c/total)*100
         sorted_percent = dict(sorted(measure_percents.items(), reverse=True, key=lambda item: item[1]))
-        
+
         # get any measures with more than a high percent (eg 20%) to name individually
-        ms=[]
-        to_pop = [] #can't pop during for loop
-        for m,p in sorted_percent.items():
-            if p>20:
+        ms = []
+        to_pop = []  # can't pop during for loop
+        for m, p in sorted_percent.items():
+            if p > 20:
                 ms.append(m)
                 to_pop.append(m)
         percent_remaining = 100
@@ -574,233 +579,230 @@ class AnalysePart:
             percent_remaining -= measure_percents[tp]
             measure_percents.pop(tp)
 
-        if len(ms)>0:
+        if len(ms) > 0:
             distribution += " mostly in bar"
-            if len(ms)>1:
+            if len(ms) > 1:
                 distribution += "s"
             distribution += " "
             distribution += self.comma_and_list(ms)
 
-        # now see if the remaining measures are mostly in a particular quarter 
-        if len(measure_percents)>0:
-            if not distribution=="":
+        # now see if the remaining measures are mostly in a particular quarter
+        if len(measure_percents) > 0:
+            if not distribution == "":
                 distribution += " and "
-            dist = {0:0, 1:0, 2:0, 3:0}
+            dist = {0: 0, 1: 0, 2: 0, 3: 0}
             for index, mp in measure_percents.items():
-                if (index>len(count_in_measures)*0.75):
-                    dist[3]+=(mp/percent_remaining)*100
-                elif (index>len(count_in_measures)*0.5):
-                    dist[2]+=(mp/percent_remaining)*100
-                elif (index>len(count_in_measures)*0.25):
-                    dist[1]+=(mp/percent_remaining)*100
+                if (index > len(count_in_measures)*0.75):
+                    dist[3] += (mp/percent_remaining)*100
+                elif (index > len(count_in_measures)*0.5):
+                    dist[2] += (mp/percent_remaining)*100
+                elif (index > len(count_in_measures)*0.25):
+                    dist[1] += (mp/percent_remaining)*100
                 else:
-                    dist[0]+=(mp/percent_remaining)*100
+                    dist[0] += (mp/percent_remaining)*100
             sorted_dist = sorted(dist.items(), reverse=True, key=lambda item: item[1])
             positions = " "
-            #if over half are in one quarter - mention it
-            if sorted_dist[0][1]>50:
+            # if over half are in one quarter - mention it
+            if sorted_dist[0][1] > 50:
                 positions += self._position_map[sorted_dist[0][0]]
-            #if over 70% are in two quarters - name them
-            elif sorted_dist[0][1] + sorted_dist[1][1]>70:
+            # if over 70% are in two quarters - name them
+            elif sorted_dist[0][1] + sorted_dist[1][1] > 70:
                 positions += self._position_map[sorted_dist[0][0]] + " and " + self._position_map[sorted_dist[1][0]]
             else:
-                #not in any two quarters - so just say how many bars
+                # not in any two quarters - so just say how many bars
                 positions += "in " + str(len(measure_percents)) + " bars throughout"
-            
+
             distribution += positions
 
         return distribution.strip()
 
-    #eg notes or chords as a percentage of events
+    # eg notes or chords as a percentage of events
     def describe_percentage(self, percent):
-        if percent>99:
+        if percent > 99:
             return "all"
-        elif percent>90:
+        elif percent > 90:
             return "almost all"
-        elif percent>75:
+        elif percent > 75:
             return "most"
-        elif percent>45:
+        elif percent > 45:
             return "lots of"
-        elif percent>30:
+        elif percent > 30:
             return "some"
-        elif percent>10:
+        elif percent > 10:
             return "a few"
-        elif percent>1:
+        elif percent > 1:
             return "very few"
         else:
             return ""
 
-    #an event that is uncommon - like accidentals - so the descriptions are weighted differently
+    # an event that is uncommon - like accidentals - so the descriptions are weighted differently
     def describe_percentage_uncommon(self, percent):
-        if percent>5:
+        if percent > 5:
             return "many"
-        elif percent>2:
+        elif percent > 2:
             return "a lot of"
-        elif percent>1:
+        elif percent > 1:
             return "quite a few"
-        elif percent>0.5:
+        elif percent > 0.5:
             return "a few"
         else:
             return "some"
 
-    
     def describe_count_list(self, count_list, total):
         description = ""
-        if total>0: 
+        if total > 0:
             for index, count_item in enumerate(count_list):
-                if count_item[1]/total>0.98:
+                if count_item[1]/total > 0.98:
                     description += "all " + str(count_item[0]) + ", "
-                elif count_item[1]/total>0.90:
+                elif count_item[1]/total > 0.90:
                     description += "almost all " + str(count_item[0]) + ", "
-                elif count_item[1]/total>0.6:
+                elif count_item[1]/total > 0.6:
                     description += "mostly " + str(count_item[0]) + ", "
-                elif count_item[1]/total>0.3:
+                elif count_item[1]/total > 0.3:
                     description += "some " + str(count_item[0]) + ", "
-            
+
         description = self.replace_end_with(description, ", ", "")
-        
+
         return description
 
-    #if no single item is over 30% for describe_count_list - then we might want to 
+    # if no single item is over 30% for describe_count_list - then we might want to
     def describe_count_list_several(self, count_list, total, item_name):
         description = ""
-        if total>0:
+        if total > 0:
             upto_percent = []
             remaining_count = 0
             progress_percent = 0
             for index, count_item in enumerate(count_list):
-                if progress_percent<40:
+                if progress_percent < 40:
                     upto_percent.append(count_item[0])
                     progress_percent += (count_item[1]/total)*100
                 else:
-                    if count_item[1]>0:
+                    if count_item[1] > 0:
                         remaining_count += 1
-            
-            if len(upto_percent)<=4:
-                description="mostly " + self.comma_and_list(upto_percent)
-                if remaining_count>1:
-                    description+="; plus " + str(remaining_count) + " other " + item_name
+
+            if len(upto_percent) <= 4:
+                description = "mostly " + self.comma_and_list(upto_percent)
+                if remaining_count > 1:
+                    description += "; plus " + str(remaining_count) + " other " + item_name
             else:
                 description = str(len(upto_percent)) + " " + item_name
                 description += ", the most common is " + enumerate(count_list)[0][0]
         return description
-
 
     def describe_summary(self):
         summary = ""
         event_count = self.chord_count + self.note_count + self.rest_count
         event_duration = self.total_chord_duration + self.total_note_duration + self.total_rest_duration
 
-        #lower weighting to number of items than to duration - ie 1 bar of semiquavers vs 8 bars of minims!
+        # lower weighting to number of items than to duration - ie 1 bar of semiquavers vs 8 bars of minims!
         percent_dictionary = {}
-        percent_dictionary["chords"] =  ((self.chord_count/event_count*50) + (self.total_chord_duration/event_duration*150)) / 2
-        percent_dictionary["individual notes"] =  ((self.note_count/event_count*50) + (self.total_note_duration/event_duration*150)) / 2
-        percent_dictionary["rests"] =  ((self.rest_count/event_count*50) + (self.total_rest_duration/event_duration*150)) / 2
-        
-        for k,v in sorted(percent_dictionary.items(), key=lambda item: item[1], reverse=True):
-            if v>1:
-                summary+=self.describe_percentage(v) + " " + k
-                if k=="chords":
+        percent_dictionary["chords"] = ((self.chord_count/event_count*50) + (self.total_chord_duration/event_duration*150)) / 2
+        percent_dictionary["individual notes"] = ((self.note_count/event_count*50) + (self.total_note_duration/event_duration*150)) / 2
+        percent_dictionary["rests"] = ((self.rest_count/event_count*50) + (self.total_rest_duration/event_duration*150)) / 2
+
+        for k, v in sorted(percent_dictionary.items(), key=lambda item: item[1], reverse=True):
+            if v > 1:
+                summary += self.describe_percentage(v) + " " + k
+                if k == "chords":
                     describe_count = self.describe_count_list(self.count_chord_common_names, self.chord_count)
-                    if describe_count!="":
-                        describe_count+=", "
+                    if describe_count != "":
+                        describe_count += ", "
                     chord_count = self.describe_count_list(self.count_rhythm_chord, self.chord_count)
-                    if chord_count!="":
+                    if chord_count != "":
                         describe_count += chord_count + ", "
                     count_notes_in_chords_list = sorted(self.count_notes_in_chords.items(), reverse=True, key=lambda item: item[1])
                     note_count = self.describe_count_list(count_notes_in_chords_list, self.chord_count)
-                    if note_count!="":
+                    if note_count != "":
                         describe_count += note_count + " notes, "
-                    if describe_count!="":
+                    if describe_count != "":
                         describe_count = self.replace_end_with(describe_count, ", ", "")
-                        summary+=" (" + describe_count + ")"
-                elif k=="individual notes":
+                        summary += " (" + describe_count + ")"
+                elif k == "individual notes":
                     describe_count = ""
                     temp = self.describe_count_list(self.count_rhythm_note, self.note_count)
-                    if temp!="":
+                    if temp != "":
                         describe_count += temp + ", "
 
                     temp = self.describe_count_list(self.count_pitch_names, self.note_count)
-                    if temp!="":
+                    if temp != "":
                         describe_count += temp + ", "
 
-                    sorted_abs_intervals  = dict(sorted(enumerate(self.count_intervals_abs), reverse=True, key=lambda item: item[1]))
+                    sorted_abs_intervals = dict(sorted(enumerate(self.count_intervals_abs), reverse=True, key=lambda item: item[1]))
                     named_abs_intervals = {}
                     for index, count in sorted_abs_intervals.items():
                         named_abs_intervals[self._interval_map[index]] = count
                     temp = self.describe_count_list(named_abs_intervals.items(), self.interval_count)
                     temp = self.replace_end_with(temp, ", ", "")
-                    if temp=="":
+                    if temp == "":
                         temp = self.describe_count_list_several(named_abs_intervals.items(), self.interval_count, "intervals")
-    
-                    #mostly ascending or descending
-                    if self.interval_ascending_count>self.interval_descending_count*2:
+
+                    # mostly ascending or descending
+                    if self.interval_ascending_count > self.interval_descending_count*2:
                         temp += ", mostly ascending"
-                    elif self.interval_descending_count>self.interval_ascending_count*2:
+                    elif self.interval_descending_count > self.interval_ascending_count*2:
                         temp += ", mostly descending"
 
-                    if temp!="":
+                    if temp != "":
                         describe_count += temp
 
                     summary += " (" + describe_count + ")"
-                elif k=="rests":
+                elif k == "rests":
                     describe_count = self.describe_count_list(self.count_rhythm_rest, self.rest_count)
                     dist = (self.describe_distribution(self.count_rests_in_measures, self.rest_count))
-                    if describe_count!="":
-                        summary+=" (" + describe_count + " - " + dist + ")"
-                summary+=", "  
-        
+                    if describe_count != "":
+                        summary += " (" + describe_count + " - " + dist + ")"
+                summary += ", "
+
         dist = ""
-        #describe the number of accidentals and where they mostly occur
-        if self.accidental_count>1:
+        # describe the number of accidentals and where they mostly occur
+        if self.accidental_count > 1:
             accidental_percent = (self.accidental_count/self.possible_accidental_count)*100
-            summary+=self.describe_percentage_uncommon(accidental_percent) + " accidentals"
+            summary += self.describe_percentage_uncommon(accidental_percent) + " accidentals"
             dist = (self.describe_distribution(self.count_accidentals_in_measures, self.accidental_count))
             if not dist == "":
                 summary += " (" + dist + "), "
-        
-        #describe the number of grace notes and where they mostly occur
-        if self.gracenote_count>1:
+
+        # describe the number of grace notes and where they mostly occur
+        if self.gracenote_count > 1:
             gracenote_percent = (self.gracenote_count/self.possible_accidental_count)*100
-            summary+=self.describe_percentage_uncommon(gracenote_percent) + " grace notes"
+            summary += self.describe_percentage_uncommon(gracenote_percent) + " grace notes"
             dist = (self.describe_distribution(self.count_gracenotes_in_measures, self.gracenote_count))
             if not dist == "":
                 summary += " (" + dist + ")."
-        
+
         summary = self.replace_end_with(summary, ", ", ".  ").capitalize()
         return summary
 
-    def replace_end_with(self, original:str, remove:str, add:str):
+    def replace_end_with(self, original: str, remove: str, add: str):
         to_return = original
         if original.endswith(remove):
             to_return = original[0:original.rfind(remove)]
             to_return += add
         return to_return
 
-    def describe_measure_repeated_many(self, measures_dictionary:dict, description:str):
+    def describe_measure_repeated_many(self, measures_dictionary: dict, description: str):
         repetition = ""
         for key, ms in measures_dictionary.items():
             percent_usage = len(ms) / len(self.measure_indexes)*100
             if percent_usage > 33:
-                repetition += "The " + description + " in bar " + str(key) + " is used " 
+                repetition += "The " + description + " in bar " + str(key) + " is used "
                 repetition += self.describe_percentage(percent_usage)
-                repetition += " of the way through.  "   
+                repetition += " of the way through.  "
         return repetition
-    
-    def describe_measure_group_repeated_many(self, measure_group_list:list, description:str):
+
+    def describe_measure_group_repeated_many(self, measure_group_list: list, description: str):
         repetition = ""
         for group in measure_group_list:
             group_repetition_percent = ((group[0][1]-group[0][0]+1)*len(group)/len(self.measure_indexes))*100
-            if group_repetition_percent>33:
-                if (group[0][1]-group[0][0]==1): # x and y or x to y.
-                    repetition+="The " + description + " in bars " + str(group[0][0]) + " and " + str(group[0][1])
+            if group_repetition_percent > 33:
+                if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
+                    repetition += "The " + description + " in bars " + str(group[0][0]) + " and " + str(group[0][1])
                 else:
-                    repetition+="The " + description + " in bars " + str(group[0][0]) + " to " + str(group[0][1])
+                    repetition += "The " + description + " in bars " + str(group[0][0]) + " to " + str(group[0][1])
                 repetition += " are used "
                 repetition += self.describe_repetition_percentage(group_repetition_percent)
                 repetition += " of the way through.  "
         return repetition
-
 
     # eg bars 1-4 are repeated all the way through...
     # eg a few individual bars repeated several times...
@@ -808,6 +810,7 @@ class AnalysePart:
     # how many individual bars out of the total - are unique?
     # how many have the same rhythm / intervals ?
     # don't list out every time that every bar is used.
+
     def describe_repetition_summary(self):
         repetition = ""
 
@@ -815,27 +818,27 @@ class AnalysePart:
         repetition += self.describe_measure_group_repeated_many(self.measure_groups_list, "pitch and rhythm")
         # see if an individual bar is used in over a thrid of the score
         repetition += self.describe_measure_repeated_many(self.repeated_measures_not_in_groups_dictionary, "pitch and rhythm")
-        
+
         # see if a group of bars (just rhythm - not full match) is over a third of the score
         repetition += self.describe_measure_group_repeated_many(self.measure_rhythm_not_full_match_groups_list, "rhythm")
         # see if an individual bar (just rhythm - not full match) is used in over a thrid of the score
         repetition += self.describe_measure_repeated_many(self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary, "rhythm")
-        
+
         # see if a group of bars (just intervals - not full match) is over a third of the score
         repetition += self.describe_measure_group_repeated_many(self.measure_intervals_not_full_match_groups_list, "intervals")
         # see if an individual bar (just intervals - not full match) is used in over a thrid of the score
         repetition += self.describe_measure_repeated_many(self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary, "intervals")
-        
+
         # at this point if you have some bars that are the same pitch and rhythm - and some bars that are the same rhythm and also the same rhythm as the previous full matches - but neither is more than 33% - then nothing gets mentioned...
-        if repetition=="":
+        if repetition == "":
             check_rhythm_match = self.calculate_repeated_measures_lists(self.measure_rhythm_analyse_indexes_dictionary, False)
             check_rhythm_match.sort(reverse=True, key=lambda item: len(item))
             for check in check_rhythm_match:
                 percent_usage = (len(check) / len(self.measure_indexes))*100
                 if percent_usage > 33:
-                    repetition += "The rhythm in bar " + str(check[0]) + " is used " 
+                    repetition += "The rhythm in bar " + str(check[0]) + " is used "
                     repetition += self.describe_percentage(percent_usage)
-                    repetition += " of the way through.  "  
+                    repetition += " of the way through.  "
                 else:
                     break
 
@@ -845,69 +848,69 @@ class AnalysePart:
             for check in check_intervals_match:
                 percent_usage = (len(check) / len(self.measure_indexes))*100
                 if percent_usage > 33:
-                    repetition += "The intervals in bar " + str(check[0]) + " is used " 
+                    repetition += "The intervals in bar " + str(check[0]) + " is used "
                     repetition += self.describe_percentage(percent_usage)
-                    repetition += " of the way through.  "  
+                    repetition += " of the way through.  "
                 else:
                     break
 
         # look at number of each repetition length
         # todo - maybe repetition_lengths should be {[section length, number of usages]}
-        repetition_lengths = {} # full match.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
-        rhythm_interval_repetition_lengths = {} # full match - just rhythm or interval.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
-        total_lengths=0
+        repetition_lengths = {}  # full match.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
+        rhythm_interval_repetition_lengths = {}  # full match - just rhythm or interval.  key = length. {number of individual sections of that length.  Not the number of times they are repeated}
+        total_lengths = 0
         for group in self.measure_groups_list:
             length = group[0][1]-group[0][0]+1
             if length in repetition_lengths:
                 repetition_lengths[length] = repetition_lengths[length] + 1
             else:
                 repetition_lengths[length] = 1
-            
+
         for group in self.measure_rhythm_not_full_match_groups_list:
             length = group[0][1]-group[0][0]+1
             if length in repetition_lengths:
                 rhythm_interval_repetition_lengths[length] = repetition_lengths[length] + 1
             else:
                 rhythm_interval_repetition_lengths[length] = 1
-            
+
         for group in self.measure_intervals_not_full_match_groups_list:
             length = group[0][1]-group[0][0]+1
             if length in repetition_lengths:
                 rhythm_interval_repetition_lengths[length] = repetition_lengths[length] + 1
             else:
                 rhythm_interval_repetition_lengths[length] = 1
-            
+
         repetition_lengths[1] = len(self.repeated_measures_not_in_groups_dictionary)
         rhythm_interval_repetition_lengths[1] = len(self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary)
         rhythm_interval_repetition_lengths[1] += len(self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary)
         print("repetition lengths = " + str(repetition_lengths))
         print("rhythm and interval repetition lengths = " + str(rhythm_interval_repetition_lengths))
 
-        for k,v in repetition_lengths.items():
+        for k, v in repetition_lengths.items():
             total_lengths += v
         sorted_repetition_lengths = sorted(repetition_lengths.items(), reverse=False, key=lambda item: item)
         temp = self.describe_count_list(sorted_repetition_lengths, total_lengths)
         temp = self.replace_end_with(temp, ", ", "")
-        if temp=="":
+        if temp == "":
             temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
-        repetition += "The repeated sections are " + temp + " measures long.  " 
-        
-        #rhythm or interval
+        repetition += "The repeated sections are " + temp + " measures long.  "
+
+        # rhythm or interval
         total_lengths = 0
-        for k,v in rhythm_interval_repetition_lengths.items():
+        for k, v in rhythm_interval_repetition_lengths.items():
             total_lengths += v
         sorted_repetition_lengths = sorted(rhythm_interval_repetition_lengths.items(), reverse=False, key=lambda item: item)
         temp = self.describe_count_list(sorted_repetition_lengths, total_lengths)
         temp = self.replace_end_with(temp, ", ", "")
-        if temp=="":
+        if temp == "":
             temp = self.describe_count_list_several(sorted_repetition_lengths, total_lengths, "lengths")
-        repetition += "The repeated sections of just rhythm / intervals are " + temp + " measures long.  " 
-        
+        repetition += "The repeated sections of just rhythm / intervals are " + temp + " measures long.  "
+
         repetition += "There are " + str(len(self.measure_analyse_indexes_list)) + " unique measures - "
         repetition += " of these, " + str(len(self.measure_rhythm_analyse_indexes_list)) + " measures have unique rhythm "
         repetition += " and " + str(len(self.measure_intervals_analyse_indexes_list)) + " measures have unique intervals...  "
 
-        if repetition!="":
+        if repetition != "":
             repetition = "<br/>"+repetition.capitalize()
         return repetition
 
@@ -919,38 +922,38 @@ class AnalysePart:
             dict[key] = value
 
     # updates dictionary at the index of the first bar each time where a section is used
-    # section first usage - says how many times it is used later.  
+    # section first usage - says how many times it is used later.
     # section second usage - says when it was first used.
     # after second usage - says first and most recent time it was used
     # repeat_what eg "full match", "rhythm", "intervals"
     # modifies the repetition_in_context dictionary
     def describe_section_usage_in_context(self, groups_list, repeat_what, repetition_in_context):
         for group in groups_list:
-            #see if a group repetition is used a lot so change what we say about it to avoid becoming too verbose
+            # see if a group repetition is used a lot so change what we say about it to avoid becoming too verbose
             group_repetition_percent = ((group[0][1]-group[0][0]+1)*len(group)/len(self.measure_indexes))*100
-            used_lots = False # todo maybe say something about this
-            if group_repetition_percent>50:
+            used_lots = False  # todo maybe say something about this
+            if group_repetition_percent > 50:
                 used_lots = True
-            
+
             and_or_through = " through "
-            if (group[0][1]-group[0][0]==1): # x and y or x to y.
+            if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
                 and_or_through = " and "
-                    
+
             temp = ""
             for index, usage in enumerate(group):
-                if index>=1:
-                    temp = repeat_what + str(usage[0]) + and_or_through + str(usage[1]) 
+                if index >= 1:
+                    temp = repeat_what + str(usage[0]) + and_or_through + str(usage[1])
                     temp += " were first used at " + str(group[0][0])
-                    if index>=2:
+                    if index >= 2:
                         temp += " and lately used at " + str(group[index-1][0])
                 else:
-                    temp = "Bars " + str(usage[0]) + and_or_through + str(usage[1]) 
+                    temp = "Bars " + str(usage[0]) + and_or_through + str(usage[1])
                     temp += " are used " + (str(len(group)-1)) + " more times.  "
-            
+
                 self.insert_or_plus_equals(repetition_in_context, usage[0], temp + ".  ")
-           
+
     # updates dictionary at the index the bar each tine where a bar is used
-    # bar first usage - says how many times it is used later.  
+    # bar first usage - says how many times it is used later.
     # bar second usage - says when it was first used.
     # after second usage - says first and most recent time it was used
     # repeat_what eg "full match", "rhythm", "intervals"
@@ -961,176 +964,175 @@ class AnalysePart:
             self.insert_or_plus_equals(repetition_in_context, key, temp)
 
             for index, m in enumerate(ms):
-                temp = repeat_what + str(m) 
+                temp = repeat_what + str(m)
                 temp += " was first used at " + str(key)
-                if index>=1:
+                if index >= 1:
                     temp += " and lately used at " + str(ms[index-1])
-                            
-                self.insert_or_plus_equals(repetition_in_context, m, temp + ".  ")
 
-        
+                self.insert_or_plus_equals(repetition_in_context, m, temp + ".  ")
 
     # when was a measure or section first used, when was it last used up until this point
     # measures 20, to, 23 are first used at 6 and last used at bar 12
     # measures 7 AND 8 are used first used at 1 and last used at bar 6
+
     def describe_repetition_in_context(self):
         print("describe repetition in context...")
 
-        repetition_in_context = {} # key = measure number.  value = string
-        #todo - could eg bar 4 could be full match for another bar - but only rhythm match for another bar.  The later rhythm match will say when it was first used - but the earlier full match won't treat it like the first rhythm match and say how many times it was used.  
+        repetition_in_context = {}  # key = measure number.  value = string
+        # todo - could eg bar 4 could be full match for another bar - but only rhythm match for another bar.  The later rhythm match will say when it was first used - but the earlier full match won't treat it like the first rhythm match and say how many times it was used.
         self.describe_section_usage_in_context(self.measure_groups_list, "Bars ", repetition_in_context)
-        self.describe_measure_usage_in_context(self.repeated_measures_not_in_groups_dictionary, "Bar ", repetition_in_context)      
-        
-        self.describe_section_usage_in_context(self.measure_rhythm_not_full_match_groups_list, "The rhythm in bars ", repetition_in_context)
-        self.describe_measure_usage_in_context(self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary, "The rhythm in bar ", repetition_in_context)      
-        
-        self.describe_section_usage_in_context(self.measure_intervals_not_full_match_groups_list, "The intervals in bars ", repetition_in_context)
-        self.describe_measure_usage_in_context(self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary, "The intervals in bar ", repetition_in_context)      
-            
-        return repetition_in_context
+        self.describe_measure_usage_in_context(self.repeated_measures_not_in_groups_dictionary, "Bar ", repetition_in_context)
 
+        self.describe_section_usage_in_context(self.measure_rhythm_not_full_match_groups_list, "The rhythm in bars ", repetition_in_context)
+        self.describe_measure_usage_in_context(self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary, "The rhythm in bar ", repetition_in_context)
+
+        self.describe_section_usage_in_context(self.measure_intervals_not_full_match_groups_list, "The intervals in bars ", repetition_in_context)
+        self.describe_measure_usage_in_context(self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary, "The intervals in bar ", repetition_in_context)
+
+        return repetition_in_context
 
     # describes groups of measures and individual measures where the notes pitches and / or rhythm are the same
     # but puts them all in one long string - which isn't very useful
+
     def describe_repetition(self):
         repetition = ""
-        if len(self.measure_groups_list)>0:
+        if len(self.measure_groups_list) > 0:
             for group in self.measure_groups_list:
-                #see if a group repetition is over half the score
+                # see if a group repetition is over half the score
                 group_repetition_percent = ((group[0][1]-group[0][0]+1)*len(group)/len(self.measure_indexes))*100
-                if group_repetition_percent>50:
-                    if (group[0][1]-group[0][0]==1): # x and y or x to y.
-                        repetition+="Bars " + str(group[0][0]) + " and " + str(group[0][1])
+                if group_repetition_percent > 50:
+                    if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
+                        repetition += "Bars " + str(group[0][0]) + " and " + str(group[0][1])
                     else:
-                        repetition+="Bars " + str(group[0][0]) + " to " + str(group[0][1])
+                        repetition += "Bars " + str(group[0][0]) + " to " + str(group[0][1])
                     repetition += " are used "
                     repetition += self.describe_repetition_percentage(group_repetition_percent)
                     repetition += " of the way through.  "
                 else:
-                    #just describe where the group is repeated
-                    if (group[0][1]-group[0][0]==1): # x and y or x to y.
-                        repetition+="Bars " + str(group[0][0]) + " and " + str(group[0][1])
+                    # just describe where the group is repeated
+                    if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
+                        repetition += "Bars " + str(group[0][0]) + " and " + str(group[0][1])
                     else:
-                        repetition+="Bars " + str(group[0][0]) + " to " + str(group[0][1])
-                    repetition+= " are used at "
+                        repetition += "Bars " + str(group[0][0]) + " to " + str(group[0][1])
+                    repetition += " are used at "
                     for index, ms in enumerate(group[1:]):
-                        if index==len(group)-2 and index>0:
+                        if index == len(group)-2 and index > 0:
                             repetition += " and "
-                        elif index<len(group)-1 and index>0:
-                            repetition += ", "  
-                        repetition+= str(ms[0])
+                        elif index < len(group)-1 and index > 0:
+                            repetition += ", "
+                        repetition += str(ms[0])
                     repetition += ".  "
-            
+
         # individual bars repeated
         for key, ms in self.repeated_measures_not_in_groups_dictionary.items():
             repetition += "Bar " + str(key) + " is used at "
             for index, m in enumerate(ms):
-                if index==len(ms)-1 and index>0:
+                if index == len(ms)-1 and index > 0:
                     repetition += " and "
-                elif index<len(ms)-1 and index>0:
+                elif index < len(ms)-1 and index > 0:
                     repetition += ", "
-                repetition+=str(m)
+                repetition += str(m)
             repetition += ".  "
 
         if repetition == "":
-            repetition+="There are no repeated bars...  "
+            repetition += "There are no repeated bars...  "
 
-        #just rhythm
+        # just rhythm
         rhythm_repetition = ""
-        if len(self.measure_rhythm_not_full_match_groups_list)>0:
+        if len(self.measure_rhythm_not_full_match_groups_list) > 0:
             for group in self.measure_rhythm_not_full_match_groups_list:
-                if (group[0][1]-group[0][0]==1): # x and y or x to y.
-                    rhythm_repetition+="The rhythm in bars " + str(group[0][0]) + " and " + str(group[0][1])
+                if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
+                    rhythm_repetition += "The rhythm in bars " + str(group[0][0]) + " and " + str(group[0][1])
                 else:
-                    rhythm_repetition+="The rhythm in bars " + str(group[0][0]) + " to " + str(group[0][1])
-                rhythm_repetition+= " are used at "
+                    rhythm_repetition += "The rhythm in bars " + str(group[0][0]) + " to " + str(group[0][1])
+                rhythm_repetition += " are used at "
                 for index, ms in enumerate(group[1:]):
-                    if index==len(group)-1 and index>0:
+                    if index == len(group)-1 and index > 0:
                         rhythm_repetition += " and "
-                    elif index<len(group)-1 and index>0:
+                    elif index < len(group)-1 and index > 0:
                         rhythm_repetition += ", "
-                    
+
                     rhythm_repetition += str(ms[0])
                 rhythm_repetition += ".  "
-        
-        # individual measures with repeated rhythm  
+
+        # individual measures with repeated rhythm
         for key, ms in self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary.items():
             rhythm_repetition += "The rhythm in bar " + str(key) + " is used at "
             for index, m in enumerate(ms):
-                if index==len(ms)-1 and index>0:
+                if index == len(ms)-1 and index > 0:
                     rhythm_repetition += " and "
-                elif index<len(ms)-1 and index>0:
+                elif index < len(ms)-1 and index > 0:
                     rhythm_repetition += ", "
-                rhythm_repetition+=str(m)
+                rhythm_repetition += str(m)
             rhythm_repetition += ".  "
-        
-        if rhythm_repetition=="":
+
+        if rhythm_repetition == "":
             rhythm_repetition = "There are no bars with just the same rhythm...  "
 
         repetition += rhythm_repetition
 
-        #intervals
+        # intervals
         interval_repetition = ""
-        if len(self.measure_intervals_not_full_match_groups_list)>0:
+        if len(self.measure_intervals_not_full_match_groups_list) > 0:
             for group in self.measure_intervals_not_full_match_groups_list:
-                if (group[0][1]-group[0][0]==1): # x and y or x to y.
-                    interval_repetition+="The intervals in bars " + str(group[0][0]) + " and " + str(group[0][1])
+                if (group[0][1]-group[0][0] == 1):  # x and y or x to y.
+                    interval_repetition += "The intervals in bars " + str(group[0][0]) + " and " + str(group[0][1])
                 else:
-                    interval_repetition+="The intervals in bars " + str(group[0][0]) + " to " + str(group[0][1])
-                interval_repetition+= " are used at "
+                    interval_repetition += "The intervals in bars " + str(group[0][0]) + " to " + str(group[0][1])
+                interval_repetition += " are used at "
                 for index, ms in enumerate(group[1:]):
-                    if index==len(group)-1 and index>0:
+                    if index == len(group)-1 and index > 0:
                         interval_repetition += " and "
-                    elif index<len(group)-1 and index>0:
+                    elif index < len(group)-1 and index > 0:
                         interval_repetition += ", "
-                    
+
                     interval_repetition += str(ms[0])
                 interval_repetition += ".  "
 
-        #individual measures with repeated intervals
+        # individual measures with repeated intervals
         for key, ms in self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary.items():
             interval_repetition += "The intervals in bar " + str(key) + " are used at "
             for index, m in enumerate(ms):
-                if index==len(ms)-1 and index>0:
+                if index == len(ms)-1 and index > 0:
                     interval_repetition += " and "
-                elif index<len(ms)-1 and index>0:
+                elif index < len(ms)-1 and index > 0:
                     interval_repetition += ", "
-                interval_repetition+=str(m)
+                interval_repetition += str(m)
             interval_repetition += ".  "
-        
-        if interval_repetition=="":
+
+        if interval_repetition == "":
             interval_repetition = "There are no bars with just the same intervals...  "
 
         repetition += interval_repetition
 
         return repetition
 
+    # analyse each part
 
-    #analyse each part
     def set_part(self, p):
         self.part = p
-        
+
         event_index = 0
-        previous_note_pitch = -1 # needed to work out intervals
-        current_measure=-1
+        previous_note_pitch = -1  # needed to work out intervals
+        current_measure = -1
         measure_analyse_indexes = AnalyseSection()
-        measure_accidentals = 0 # count
-        measure_gracenotes = 0 # count
-        measure_rests = 0 # count
+        measure_accidentals = 0  # count
+        measure_gracenotes = 0  # count
+        measure_rests = 0  # count
         for n in self.part.flat.notesAndRests:
-            #the start of a new measure
-            if (n.measureNumber>current_measure):
-                #todo - if a measure doesn't have any notes or rests then it won't be added to measure_indexes etc and will cause errors later when looking for groups etc
+            # the start of a new measure
+            if (n.measureNumber > current_measure):
+                # todo - if a measure doesn't have any notes or rests then it won't be added to measure_indexes etc and will cause errors later when looking for groups etc
                 self.measure_indexes[n.measureNumber] = event_index
                 current_measure = n.measureNumber
-                if (len(measure_analyse_indexes.analyse_indexes)>0): #first time through will be empty
+                if (len(measure_analyse_indexes.analyse_indexes) > 0):  # first time through will be empty
                     self.count_accidentals_in_measures[current_measure-1] = measure_accidentals
                     measure_accidentals = 0
                     self.count_gracenotes_in_measures[current_measure-1] = measure_gracenotes
                     measure_gracenotes = 0
                     self.count_rests_in_measures[current_measure-1] = measure_rests
                     measure_rests = 0
-                    
+
                     index = self.find_section(measure_analyse_indexes, self.measure_analyse_indexes_list, 0)
                     if index == -1:
                         self.measure_analyse_indexes_list.append(measure_analyse_indexes)
@@ -1140,8 +1142,8 @@ class AnalysePart:
                     else:
                         self.measure_analyse_indexes_dictionary[index].append(current_measure-1)
                         self.measure_analyse_indexes_all[current_measure-1] = [index, len(self.measure_analyse_indexes_dictionary[index])-1]
-                    
-                    #measures with matching rhythm
+
+                    # measures with matching rhythm
                     index = self.find_section(measure_analyse_indexes, self.measure_rhythm_analyse_indexes_list, 1)
                     if index == -1:
                         self.measure_rhythm_analyse_indexes_list.append(measure_analyse_indexes)
@@ -1151,8 +1153,8 @@ class AnalysePart:
                     else:
                         self.measure_rhythm_analyse_indexes_dictionary[index].append(current_measure-1)
                         self.measure_rhythm_analyse_indexes_all[current_measure-1] = [index, len(self.measure_rhythm_analyse_indexes_dictionary[index])-1]
-                    
-                    #measures with matching intervals
+
+                    # measures with matching intervals
                     if (self.does_section_contain_intervals(measure_analyse_indexes)):
                         index = self.find_section(measure_analyse_indexes, self.measure_intervals_analyse_indexes_list, 2)
                         if index == -1:
@@ -1163,9 +1165,9 @@ class AnalysePart:
                         else:
                             self.measure_intervals_analyse_indexes_dictionary[index].append(current_measure-1)
                             self.measure_intervals_analyse_indexes_all[current_measure-1] = [index, len(self.measure_intervals_analyse_indexes_dictionary[index])-1]
-                        
+
                     measure_analyse_indexes = AnalyseSection()
-                    previous_note_pitch=-1 # reset interval comparison for each measure
+                    previous_note_pitch = -1  # reset interval comparison for each measure
 
             ai = AnalyseIndex(event_index)
             if n.isRest:
@@ -1177,27 +1179,27 @@ class AnalysePart:
                 else:
                     self.rhythm_rest_dictionary[d].append(event_index)
                 ai.rhythm_rest_index = [d, len(self.rhythm_rest_dictionary.get(d))-1]
-                
+
                 previous_note_pitch = -1
                 self.total_rest_duration += d
-                self.rest_count += 1 
-            elif n.isChord and type(n).__name__ != 'ChordSymbol': 
-                #todo - maybe analyse ChordSymbol too - it won't cause an error - just thinks they are grace notes and affects counting notes / pitches / repetition etc
+                self.rest_count += 1
+            elif n.isChord and type(n).__name__ != 'ChordSymbol':
+                # todo - maybe analyse ChordSymbol too - it won't cause an error - just thinks they are grace notes and affects counting notes / pitches / repetition etc
                 ai.event_type = 'c'
-                
+
                 d = n.duration.quarterLength
-                if d==0.0:
+                if d == 0.0:
                     measure_gracenotes += len(n.pitches)
                     self.gracenote_count += len(n.pitches)
 
-                if d>0.0: #bigger than a grace note because they are counted separately
+                if d > 0.0:  # bigger than a grace note because they are counted separately
                     if self.rhythm_chord_dictionary.get(d) == None:
                         self.rhythm_chord_dictionary[d] = [event_index]
                     else:
                         self.rhythm_chord_dictionary[d].append(event_index)
                     ai.rhythm_chord_index = [d, len(self.rhythm_chord_dictionary.get(d))-1]
-                    
-                if len(n.pitches)<11: #unlikely as not enough fingers - but best to check!
+
+                if len(n.pitches) < 11:  # unlikely as not enough fingers - but best to check!
                     self.count_notes_in_chords[len(n.pitches)] += 1
 
                 index = self.find_chord(n)
@@ -1208,7 +1210,7 @@ class AnalysePart:
                 else:
                     self.chord_pitches_dictionary[index].append(event_index)
                 ai.chord_pitches_index = [index, len(self.chord_pitches_dictionary.get(index))-1]
-                
+
                 chord_intervals = self.make_chord_intervals(n)
                 index = self.find_chord_intervals(chord_intervals)
                 if index == -1:
@@ -1218,9 +1220,9 @@ class AnalysePart:
                 else:
                     self.chord_intervals_dictionary[index].append(event_index)
                 ai.chord_interval_index = [index, len(self.chord_intervals_dictionary.get(index))-1]
-                
+
                 common_name = n.commonName
-                #music21 describes eg A, D, E as a quatral trichord - ie E, A, D are perfect fourths - but I prefer Suspended 4ths or 2nds...
+                # music21 describes eg A, D, E as a quatral trichord - ie E, A, D are perfect fourths - but I prefer Suspended 4ths or 2nds...
                 if chord_intervals == [0, 5, 7]:
                     common_name = "Suspended 4th"
                 elif chord_intervals == [0, 2, 7]:
@@ -1230,8 +1232,8 @@ class AnalysePart:
                 else:
                     self.chord_common_name_dictionary[common_name].append(event_index)
                 ai.chord_name_index = [common_name, len(self.chord_common_name_dictionary.get(common_name))-1]
-                
-                #count accidentals in the chord
+
+                # count accidentals in the chord
                 for p in n.pitches:
                     if p.accidental is not None and p.accidental.displayStatus == True:
                         measure_accidentals += 1
@@ -1242,23 +1244,23 @@ class AnalysePart:
                 self.chord_count += 1
             elif n.isChord == False:
                 ai.event_type = 'n'
-                
+
                 if n.pitch.accidental is not None and n.pitch.accidental.displayStatus == True:
                     measure_accidentals += 1
                     self.accidental_count += 1
                 self.possible_accidental_count += 1
-                
+
                 self.pitch_number_dictionary[n.pitch.midi].append(event_index)
                 ai.pitch_number_index = [n.pitch.midi, len(self.pitch_number_dictionary[n.pitch.midi])-1]
-                
+
                 if self.pitch_name_dictionary.get(n.pitch.name) == None:
                     self.pitch_name_dictionary[n.pitch.name] = [event_index]
                 else:
                     self.pitch_name_dictionary[n.pitch.name].append(event_index)
                 ai.pitch_name_index = [n.pitch.name, len(self.pitch_name_dictionary[n.pitch.name])-1]
-                
-                #intervals
-                if (previous_note_pitch>-1):
+
+                # intervals
+                if (previous_note_pitch > -1):
                     interval = n.pitch.midi-previous_note_pitch
                     if self.interval_dictionary.get(interval) == None:
                         self.interval_dictionary[interval] = [event_index]
@@ -1266,37 +1268,37 @@ class AnalysePart:
                         self.interval_dictionary[interval].append(event_index)
                     ai.interval_index = [interval, len(self.interval_dictionary.get(interval))-1]
 
-                    if interval>0:
+                    if interval > 0:
                         self.interval_ascending_count += 1
-                    elif interval<0:
+                    elif interval < 0:
                         self.interval_descending_count += 1
                     else:
                         self.interval_unison_count += 1
                     self.interval_count += 1
 
                     interval_abs = abs(interval)
-                    if interval_abs<24:
+                    if interval_abs < 24:
                         self.count_intervals_abs[interval_abs] += 1
 
                 # duration
-                d = n.duration.quarterLength #numeric value
-                if d==0.0:
+                d = n.duration.quarterLength  # numeric value
+                if d == 0.0:
                     measure_gracenotes += 1
                     self.gracenote_count += 1
                     print("I'm a grace note note...")
                     print(n)
-                if d>0.0: #bigger than a grace note because they are counted separately
+                if d > 0.0:  # bigger than a grace note because they are counted separately
                     if self.rhythm_note_dictionary.get(d) == None:
                         self.rhythm_note_dictionary[d] = [event_index]
                     else:
                         self.rhythm_note_dictionary[d].append(event_index)
                     ai.rhythm_note_index = [d, len(self.rhythm_note_dictionary.get(d))-1]
-                    
+
                 previous_note_pitch = n.pitch.midi
                 self.total_note_duration += d
                 self.note_count += 1
-            
-            #AnalyseIndex - ie is it a unique event
+
+            # AnalyseIndex - ie is it a unique event
             index = self.find_analyse_index(ai)
             if index == -1:
                 self.analyse_indexes_list.append(ai)
@@ -1307,16 +1309,16 @@ class AnalysePart:
                 self.analyse_indexes_dictionary[index].append(event_index)
                 self.analyse_indexes_all[event_index] = [index, len(self.analyse_indexes_dictionary[index])-1]
 
-            #self.analyse_indexes.append(ai)
+            # self.analyse_indexes.append(ai)
             measure_analyse_indexes.analyse_indexes.append(ai)
-            event_index = event_index + 1 
+            event_index = event_index + 1
 
-        #add last measure
-        if (len(measure_analyse_indexes.analyse_indexes)>0):
+        # add last measure
+        if (len(measure_analyse_indexes.analyse_indexes) > 0):
             self.count_accidentals_in_measures[current_measure-1] = measure_accidentals
             self.count_gracenotes_in_measures[current_measure-1] = measure_gracenotes
             self.count_rests_in_measures[current_measure-1] = measure_rests
-            
+
             index = self.find_section(measure_analyse_indexes, self.measure_analyse_indexes_list, 0)
             if index == -1:
                 self.measure_analyse_indexes_list.append(measure_analyse_indexes)
@@ -1326,8 +1328,8 @@ class AnalysePart:
             else:
                 self.measure_analyse_indexes_dictionary[index].append(current_measure)
                 self.measure_analyse_indexes_all[current_measure] = [index, len(self.measure_analyse_indexes_dictionary[index])-1]
-        
-            #measures with matching rhythm
+
+            # measures with matching rhythm
             index = self.find_section(measure_analyse_indexes, self.measure_rhythm_analyse_indexes_list, 1)
             if index == -1:
                 self.measure_rhythm_analyse_indexes_list.append(measure_analyse_indexes)
@@ -1337,8 +1339,8 @@ class AnalysePart:
             else:
                 self.measure_rhythm_analyse_indexes_dictionary[index].append(current_measure)
                 self.measure_rhythm_analyse_indexes_all[current_measure] = [index, len(self.measure_rhythm_analyse_indexes_dictionary[index])-1]
-            
-            #measures with matching intervals
+
+            # measures with matching intervals
             if (self.does_section_contain_intervals(measure_analyse_indexes)):
                 index = self.find_section(measure_analyse_indexes, self.measure_intervals_analyse_indexes_list, 2)
                 if index == -1:
@@ -1349,7 +1351,7 @@ class AnalysePart:
                 else:
                     self.measure_intervals_analyse_indexes_dictionary[index].append(current_measure)
                     self.measure_intervals_analyse_indexes_all[current_measure] = [index, len(self.measure_intervals_analyse_indexes_dictionary[index])-1]
-                
+
         print("\n Done set_part() - note count = " + str(self.note_count) + " chord count = " + str(self.chord_count) + " rest count = " + str(self.rest_count) + "...")
 
         print("self.measure_analyse_indexes_all")
@@ -1358,43 +1360,43 @@ class AnalysePart:
         self.repeated_measures_lists = self.calculate_repeated_measures_lists(self.measure_analyse_indexes_dictionary, False)
         self.measure_groups_list = self.calculate_measure_groups(self.measure_analyse_indexes_all, self.measure_analyse_indexes_dictionary)
         self.repeated_measures_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.measure_analyse_indexes_dictionary.values(), self.measure_groups_list)
-        
+
         self.repeated_measures_lists_rhythm = self.calculate_repeated_measures_lists(self.measure_rhythm_analyse_indexes_dictionary, True)
         self.measure_rhythm_not_full_match_groups_list = self.calculate_measure_groups(self.measure_rhythm_analyse_indexes_all, self.measure_rhythm_analyse_indexes_dictionary)
         self.repeated_rhythm_measures_not_full_match_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.repeated_measures_lists_rhythm, self.measure_rhythm_not_full_match_groups_list)
-        
+
         self.repeated_measures_lists_intervals = self.calculate_repeated_measures_lists(self.measure_intervals_analyse_indexes_dictionary, True)
         self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.repeated_measures_lists_intervals, self.measure_intervals_not_full_match_groups_list)
         self.repeated_intervals_measures_not_full_match_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.repeated_measures_lists_intervals, self.measure_intervals_not_full_match_groups_list)
-        
-        #make lists of index and totals then sort by totals for eg most common pitch / rhythm etc
+
+        # make lists of index and totals then sort by totals for eg most common pitch / rhythm etc
         self.count_pitches = self.count_dictionary(self.pitch_number_dictionary)
         self.count_pitch_names = self.count_dictionary(self.pitch_name_dictionary)
         self.count_intervals = self.count_dictionary(self.interval_dictionary)
         self.count_chord_common_names = self.count_dictionary(self.chord_common_name_dictionary)
-        
+
         self.count_rhythm_note = self.count_dictionary(self.rhythm_note_dictionary)
         self.count_rhythm_rest = self.count_dictionary(self.rhythm_rest_dictionary)
         self.count_rhythm_chord = self.count_dictionary(self.rhythm_chord_dictionary)
         self.rename_count_list_keys(self.count_rhythm_note, self._DURATION_MAP)
         self.rename_count_list_keys(self.count_rhythm_rest, self._DURATION_MAP)
         self.rename_count_list_keys(self.count_rhythm_chord, self._DURATION_MAP)
-        
-        #dictionaries with list indexes as keys
+
+        # dictionaries with list indexes as keys
         self.count_chord_pitches = self.count_dictionary(self.chord_pitches_dictionary)
         self.count_chord_intervals = self.count_dictionary(self.chord_intervals_dictionary)
-        
 
-    #count_list is like count_rhythm_note [[duration of individual note, count]] ordered by descending count.         
-    #duration is a decimal number of quarter notes ie 0.5 for an eight note - 
-    #swaps numeric duration for words
+    # count_list is like count_rhythm_note [[duration of individual note, count]] ordered by descending count.
+    # duration is a decimal number of quarter notes ie 0.5 for an eight note -
+    # swaps numeric duration for words
+
     def rename_count_list_keys(self, count_list, key_names):
         for item in count_list:
             if item[0] in key_names:
                 item[0] = key_names.get(item[0])
-    
-    #d = {key, [list]} eg pitch_name_dictionary
-    #returns eg [[C#, 5], [A,3]]
+
+    # d = {key, [list]} eg pitch_name_dictionary
+    # returns eg [[C#, 5], [A,3]]
     def count_dictionary(self, d):
         sorted_list = []
         for k, v in d.items():

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -703,7 +703,7 @@ class AnalysePart:
         if self.gracenote_count>1:
             gracenote_percent = (self.gracenote_count/self.possible_accidental_count)*100
             summary+=self.describe_percentage_uncommon(gracenote_percent) + " grace notes"
-            dist = (self.describe_distribution(self.count_gracenotes_in_measures, self.accidental_count))
+            dist = (self.describe_distribution(self.count_gracenotes_in_measures, self.gracenote_count))
             if not dist == "":
                 summary += " (" + dist + ")."
         
@@ -904,8 +904,9 @@ class AnalysePart:
                 
                 previous_note_pitch = -1
                 self.total_rest_duration += d
-                self.rest_count += 1
-            elif n.isChord:
+                self.rest_count += 1 
+            elif n.isChord and type(n).__name__ != 'ChordSymbol': 
+                #todo - maybe analyse ChordSymbol too - it won't cause an error - just thinks they are grace notes and affects counting notes / pitches / repetition etc
                 ai.event_type = 'c'
                 
                 d = n.duration.quarterLength
@@ -1006,6 +1007,8 @@ class AnalysePart:
                 if d==0.0:
                     measure_gracenotes += 1
                     self.gracenote_count += 1
+                    print("I'm a grace note note...")
+                    print(n)
                 if d>0.0: #bigger than a grace note because they are counted separately
                     if self.rhythm_note_dictionary.get(d) == None:
                         self.rhythm_note_dictionary[d] = [event_index]
@@ -1072,7 +1075,10 @@ class AnalysePart:
                     self.measure_intervals_analyse_indexes_all[current_measure] = [index, len(self.measure_intervals_analyse_indexes_dictionary[index])-1]
                 
         print("\n Done set_part() - note count = " + str(self.note_count) + " chord count = " + str(self.chord_count) + " rest count = " + str(self.rest_count) + "...")
-                
+
+        print("chord pitches dictionary = ")
+        print(self.chord_pitches_dictionary)
+
         self.repeated_measures_lists = self.calculate_repeated_measures_lists(self.measure_analyse_indexes_dictionary, False)
         self.measure_groups_list = self.calculate_measure_groups(self.measure_analyse_indexes_all, self.measure_analyse_indexes_dictionary)
         self.repeated_measures_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.measure_analyse_indexes_dictionary.values(), self.measure_groups_list)

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -82,7 +82,7 @@ class MusicAnalyser:
         self.analyse_parts = []
         self.repetition_parts = []
         self.summary_parts = []
-        self.repetition_in_contexts = {} # key = part index
+        self.repetition_in_contexts = {}  # key = part index
         self.general_summary = ""
 
         analyse_index = 0
@@ -1243,42 +1243,46 @@ class AnalysePart:
                 self.total_chord_duration += d
                 self.chord_count += 1
             elif n.isChord == False:
-                ai.event_type = 'n'
-
-                if n.pitch.accidental is not None and n.pitch.accidental.displayStatus == True:
-                    measure_accidentals += 1
-                    self.accidental_count += 1
-                self.possible_accidental_count += 1
-
-                self.pitch_number_dictionary[n.pitch.midi].append(event_index)
-                ai.pitch_number_index = [n.pitch.midi, len(self.pitch_number_dictionary[n.pitch.midi])-1]
-
-                if self.pitch_name_dictionary.get(n.pitch.name) == None:
-                    self.pitch_name_dictionary[n.pitch.name] = [event_index]
+                if isinstance(n, note.Unpitched):
+                    ai.event_type = 'u'
                 else:
-                    self.pitch_name_dictionary[n.pitch.name].append(event_index)
-                ai.pitch_name_index = [n.pitch.name, len(self.pitch_name_dictionary[n.pitch.name])-1]
 
-                # intervals
-                if (previous_note_pitch > -1):
-                    interval = n.pitch.midi-previous_note_pitch
-                    if self.interval_dictionary.get(interval) == None:
-                        self.interval_dictionary[interval] = [event_index]
+                    ai.event_type = 'n'
+
+                    if n.pitch.accidental is not None and n.pitch.accidental.displayStatus == True:
+                        measure_accidentals += 1
+                        self.accidental_count += 1
+                    self.possible_accidental_count += 1
+
+                    self.pitch_number_dictionary[n.pitch.midi].append(event_index)
+                    ai.pitch_number_index = [n.pitch.midi, len(self.pitch_number_dictionary[n.pitch.midi])-1]
+
+                    if self.pitch_name_dictionary.get(n.pitch.name) == None:
+                        self.pitch_name_dictionary[n.pitch.name] = [event_index]
                     else:
-                        self.interval_dictionary[interval].append(event_index)
-                    ai.interval_index = [interval, len(self.interval_dictionary.get(interval))-1]
+                        self.pitch_name_dictionary[n.pitch.name].append(event_index)
+                    ai.pitch_name_index = [n.pitch.name, len(self.pitch_name_dictionary[n.pitch.name])-1]
 
-                    if interval > 0:
-                        self.interval_ascending_count += 1
-                    elif interval < 0:
-                        self.interval_descending_count += 1
-                    else:
-                        self.interval_unison_count += 1
-                    self.interval_count += 1
+                    # intervals
+                    if (previous_note_pitch > -1):
+                        interval = n.pitch.midi-previous_note_pitch
+                        if self.interval_dictionary.get(interval) == None:
+                            self.interval_dictionary[interval] = [event_index]
+                        else:
+                            self.interval_dictionary[interval].append(event_index)
+                        ai.interval_index = [interval, len(self.interval_dictionary.get(interval))-1]
 
-                    interval_abs = abs(interval)
-                    if interval_abs < 24:
-                        self.count_intervals_abs[interval_abs] += 1
+                        if interval > 0:
+                            self.interval_ascending_count += 1
+                        elif interval < 0:
+                            self.interval_descending_count += 1
+                        else:
+                            self.interval_unison_count += 1
+                        self.interval_count += 1
+
+                        interval_abs = abs(interval)
+                        if interval_abs < 24:
+                            self.count_intervals_abs[interval_abs] += 1
 
                 # duration
                 d = n.duration.quarterLength  # numeric value
@@ -1294,7 +1298,10 @@ class AnalysePart:
                         self.rhythm_note_dictionary[d].append(event_index)
                     ai.rhythm_note_index = [d, len(self.rhythm_note_dictionary.get(d))-1]
 
-                previous_note_pitch = n.pitch.midi
+                if isinstance(n, note.Unpitched):
+                    previous_note_pitch = -1
+                else:
+                    previous_note_pitch = n.pitch.midi
                 self.total_note_duration += d
                 self.note_count += 1
 

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -721,7 +721,7 @@ class AnalysePart:
             if not dist == "":
                 summary += " (" + dist + ")."
         
-        summary = self.replace_end_with(summary, ", ", ".  ")
+        summary = self.replace_end_with(summary, ", ", ".  ").capitalize()
         return summary
 
     def replace_end_with(self, original:str, remove:str, add:str):
@@ -862,7 +862,7 @@ class AnalysePart:
         repetition += " and " + str(len(self.measure_intervals_analyse_indexes_list)) + " measures have unique intervals...  "
 
         if repetition!="":
-            repetition = "<br/>"+repetition
+            repetition = "<br/>"+repetition.capitalize()
         return repetition
 
     # you get a KeyError if you do dict[key] += value if the key doesn't already exist...

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -79,11 +79,16 @@ class MusicAnalyser:
             self.analyse_parts[part_index].set_part(p)
             part_index = part_index + 1
         
-        self.repetition_left_hand = self.analyse_parts[1].describe_repetition()
         self.repetition_right_hand = self.analyse_parts[0].describe_repetition()
-
-        self.summary_left_hand = self.analyse_parts[1].describe_summary()
         self.summary_right_hand = self.analyse_parts[0].describe_summary()
+        
+        #temporary fix to make it work with only a single part
+        if len(self.analyse_parts)>1:
+            self.repetition_left_hand = self.analyse_parts[1].describe_repetition()
+            self.summary_left_hand = self.analyse_parts[1].describe_summary()
+        else:
+            self.repetition_left_hand = ""
+            self.summary_left_hand = ""
 
 
 class AnalysePart:

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -1076,9 +1076,6 @@ class AnalysePart:
                 
         print("\n Done set_part() - note count = " + str(self.note_count) + " chord count = " + str(self.chord_count) + " rest count = " + str(self.rest_count) + "...")
 
-        print("chord pitches dictionary = ")
-        print(self.chord_pitches_dictionary)
-
         self.repeated_measures_lists = self.calculate_repeated_measures_lists(self.measure_analyse_indexes_dictionary, False)
         self.measure_groups_list = self.calculate_measure_groups(self.measure_analyse_indexes_all, self.measure_analyse_indexes_dictionary)
         self.repeated_measures_not_in_groups_dictionary = self.calculate_repeated_measures_not_in_groups(self.measure_analyse_indexes_dictionary.values(), self.measure_groups_list)

--- a/lib/musicAnalyser.py
+++ b/lib/musicAnalyser.py
@@ -359,8 +359,11 @@ class AnalysePart:
         
     # do two measures have matching pitch / rhythm / intervals etc    
     def is_measure_used_at(self, indexes_all, current_measure_index, check_measure_index):
+        #todo - these two checks are in case a measure doesn't have anything in then won't be added as a key to the dictionary...
         if not check_measure_index in indexes_all:
             return False
+        elif not current_measure_index in indexes_all:
+            return False 
         else:    
             if (indexes_all[current_measure_index][0]==indexes_all[check_measure_index][0]):
                 return True
@@ -447,7 +450,7 @@ class AnalysePart:
                 #eg if 4 is used at 6, check if 5 is used at 7
                 if gap>1:
                     group_size=1
-                    while (self.is_measure_used_at(from_indexes_all, look_at_measure + group_size, look_at_measure + group_size + gap) and group_size<gap):
+                    while (group_size<gap and (look_at_measure + group_size + gap) in from_indexes_all) and (self.is_measure_used_at(from_indexes_all, look_at_measure + group_size, look_at_measure + group_size + gap)):
                         group_size+=1
                     
                     group_size-=1
@@ -845,6 +848,7 @@ class AnalysePart:
         for n in self.part.flat.notesAndRests:
             #the start of a new measure
             if (n.measureNumber>current_measure):
+                #todo - if a measure doesn't have any notes or rests then it won't be added to measure_indexes etc and will cause errors later when looking for groups etc
                 self.measure_indexes[n.measureNumber] = event_index
                 current_measure = n.measureNumber
                 if (len(measure_analyse_indexes.analyse_indexes)>0): #first time through will be empty
@@ -1075,6 +1079,9 @@ class AnalysePart:
                     self.measure_intervals_analyse_indexes_all[current_measure] = [index, len(self.measure_intervals_analyse_indexes_dictionary[index])-1]
                 
         print("\n Done set_part() - note count = " + str(self.note_count) + " chord count = " + str(self.chord_count) + " rest count = " + str(self.rest_count) + "...")
+
+        print("self.measure_analyse_indexes_all")
+        print(self.measure_analyse_indexes_all)
 
         self.repeated_measures_lists = self.calculate_repeated_measures_lists(self.measure_analyse_indexes_dictionary, False)
         self.measure_groups_list = self.calculate_measure_groups(self.measure_analyse_indexes_all, self.measure_analyse_indexes_dictionary)

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -131,6 +131,13 @@ Click:
                     Repetition - {{repetition_in_contexts[instrument_index][bar]}} 
                     <br/> <br/>
                 {% endif %}
+
+                {% if bar in time_and_keys %}
+                    {% for tk in time_and_keys[bar] %}
+                        {{tk}}<br/>
+                    {% endfor %}
+                    <br/>
+                {% endif %}
                 {#  Loop over each beat pulling out the hand-based dictionaries #}
                 {% for beat, events_per_hand in events_for_beats.items() %}
                     {# {% if not loop.first %}<br/>{% endif %}#}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -39,6 +39,13 @@
     <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['left'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
     <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['right'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
 
+    <br/><br/>
+    <b>Instrument MIDIs</b><br/>
+    {% for index, ins in segment.selected_instruments_midis.items() %}
+        <a href="#" onClick="MIDIjs.play('{{ ins.midi }}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
+    {% endfor %}
+    <br/><br/>
+
     {#  Loop over each bar pulling out the beat-based dictionaries #}
     {% for bar, events_for_beats in segment.events_by_bar_and_beat|dictsort %}
         {% if not loop.first %}<br/><br/>{% endif %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -26,7 +26,7 @@
 Tempo:
 <select class="ddlTempo" name="tempo" id="ddlTempo">
     <option value="50">50%</option>
-    <option value="100">100%</option>
+    <option value="100" selected>100%</option>
     <option value="150">150%</option>
 </select>
 &nbsp; &nbsp;
@@ -71,7 +71,7 @@ Click:
     Tempo:
     <select class="ddlTempo" name="tempo">
         <option value="50">50%</option>
-        <option value="100">100%</option>
+        <option value="100" selected>100%</option>
         <option value="150">150%</option>
     </select>
     &nbsp; &nbsp;

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -35,10 +35,6 @@
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
 
-    <a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['both'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, both hands</a>
-    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['left'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, left hand</a>
-    <br/><a href="#" onClick="MIDIjs.play('{{ segment.midi_filenames['right'] }}'); return false;">Play bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, right hand</a>
-
     <br/><br/>
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
@@ -58,7 +54,7 @@
 
         {#  Loop over each beat pulling out the hand-based dictionaries #}
         {% for beat, events_per_hand in events_for_beats.items() %}
-{#          {% if not loop.first %}<br/>{% endif %}#}
+            {# {% if not loop.first %}<br/>{% endif %}#}
             <div>Beat {{ beat | int  }}:
             {#  Loop over each hand #}
             {% for hand in ('Both', 'Left', 'Right', 'BothAfter') %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -139,12 +139,12 @@ Click:
                     <br/>
                 {% endif %}
                 {#  Loop over each beat pulling out the hand-based dictionaries #}
-                {% for beat, events_per_hand in events_for_beats.items() %}
+                {% for beat, events_per_beat in events_for_beats.items() %}
                     {# {% if not loop.first %}<br/>{% endif %}#}
                     <div>Beat {{ beat }}:
                     {% set previous_event = {'value' : None} %}
                     {#  Loop over each hand #}
-                    {% for voice, events_per_voice in events_per_hand|dictsort|reverse %}
+                    {% for voice, events_per_voice in events_per_beat|dictsort %}
                         {% if not loop.first %} together with {% endif %}
                         {% for pitch_space, events in events_per_voice.items() %}
                             {% if not loop.first %}, {% endif %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -34,18 +34,29 @@
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
-
-    <br/><br/>
+    {% if play_all %}
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <br/>
+    {% endif %}
+    {% if play_selected %}
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <br/>
+    {% endif %}
+    {% if play_unselected %}
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <br/>
+    {% endif %}
+    <br/>
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
-        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
+        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
         <li style="margin-left:15px; list-style-type:none;">
             {% for midipart in ins.midi_parts %}
-                <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+                <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
             {% endfor %}
         </li>
     {% endfor %}
-    <br/><br/>
+    <br/>
 
     {#  Loop over each bar pulling out the beat-based dictionaries #}
     {% for bar, events_for_beats in segment.events_by_bar_and_beat|dictsort %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -125,9 +125,12 @@ Click:
             {% endif %}
             {#  Loop over each bar pulling out the beat-based dictionaries #}
             {% for bar, events_for_beats in part_description.items() %}
-                {% if not loop.first %}<br/>{% endif %}
+                {#% if not loop.first %}<br/>{% endif %#}
                 <h4>Bar: {{ bar }}</h4>
-
+                {% if bar in repetition_in_contexts[instrument_index] %}
+                    Repetition - {{repetition_in_contexts[instrument_index][bar]}} 
+                    <br/> <br/>
+                {% endif %}
                 {#  Loop over each beat pulling out the hand-based dictionaries #}
                 {% for beat, events_per_hand in events_for_beats.items() %}
                     {# {% if not loop.first %}<br/>{% endif %}#}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -5,7 +5,6 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <meta name="robots" content="noindex" />
     
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <!-- midi.js package -->
     <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
 {#   <!-- extras -->#}
@@ -190,45 +189,51 @@ Click:
 {#</script>#}
 
 <script>
-    $(document).ready(function() {
-        $(".ddlTempo").on('change', function (event) {
-            event.stopPropagation();
-            event.stopImmediatePropagation();
-            let tempo = this.value
-            let click = $("#ddlClick").val()
-            $('.lnkPlay').each(function(i, obj) {
-                let href=$(this).attr('onClick');
-                let posTempo = href.indexOf('&t=')
-                href = href.substr(0,posTempo)
-                $(this).attr('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
-            });
+    document.addEventListener("DOMContentLoaded", (event) => {
+        document.querySelectorAll('.ddlTempo').forEach((ddlTempo) => {
+            ddlTempo.addEventListener("change", function(event) {
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+                let tempo = ddlTempo.value;
+                let ddlClick = document.querySelector("#ddlClick") 
+                let click = ddlClick.value;
+                
+                document.querySelectorAll('.lnkPlay').forEach((lnkPlay) => {
+                    let href = lnkPlay.getAttribute("onClick")
+                    let posTempo = href.indexOf("&t=")
+                    href = href.substr(0,posTempo)
+                    lnkPlay.setAttribute('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
+                })
+                
+                document.querySelectorAll('.ddlTempo').forEach((ddlTempo2) => {
+                    ddlTempo2.value = ddlTempo.value
+                })
+            })
+        }) 
 
-            $('.ddlTempo').each(function(ddlIndex, ddlObj) {
-                ddlObj.value=tempo
-            });
+        //click drop downs
+        document.querySelectorAll('.ddlClick').forEach((ddlClick) => {
+            ddlClick.addEventListener("change", function(event) {
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+                let click = ddlClick.value;
+                let ddlTempo = document.querySelector("#ddlTempo") 
+                let tempo = ddlTempo.value;
+                
+                document.querySelectorAll('.lnkPlay').forEach((lnkPlay) => {
+                    let href = lnkPlay.getAttribute("onClick")
+                    let posTempo = href.indexOf("&t=")
+                    href = href.substr(0,posTempo)
+                    lnkPlay.setAttribute('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
+                })
+                
+                document.querySelectorAll('.ddlClick').forEach((ddlClick2) => {
+                    ddlClick2.value = ddlClick.value
+                })
+            })
+        }) 
+    })
 
-        });
-    });
-
-    $(document).ready(function() {
-        $(".ddlClick").on('change', function (event) {
-            event.stopPropagation();
-            event.stopImmediatePropagation();
-            let click = this.value
-            let tempo = $("#ddlTempo").val()
-            $('.lnkPlay').each(function(i, obj) {
-                let href=$(this).attr('onClick');
-                let posTempo = href.indexOf('&t=')
-                href = href.substr(0,posTempo)
-                $(this).attr('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
-            });
-
-            $('.ddlClick').each(function(ddlIndex, ddlObj) {
-                ddlObj.value=click
-            });
-
-        });
-    });
 </script>
 </body>
 </html>

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -5,6 +5,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <meta name="robots" content="noindex" />
     
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <!-- midi.js package -->
     <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
 {#   <!-- extras -->#}
@@ -22,25 +23,40 @@
 <p>Music, both hands, a bar at a time, beat by beat</p>
 
 <h2>Entire score:</h2>
+Tempo:
+<select class="ddlTempo" name="tempo" id="ddlTempo">
+    <option value="50">50%</option>
+    <option value="100">100%</option>
+    <option value="150">150%</option>
+</select>
+&nbsp; &nbsp;
+Click:
+<select class="ddlClick" name="click" id="ddlClick">
+    <option value="n">None</option>
+    <option value="ba">Bars</option>
+    <option value="be">Beats</option>
+    <option value="qe">Eighth notes / Quavers</option>
+</select>
+<br/>
 {% if play_all %}
-    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All Instruments </a>
+    <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ full_score_midis.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All Instruments </a>
     <br/>
 {% endif %}
 {% if play_selected %}
-    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected Instruments </a>
+    <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ full_score_midis.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected Instruments </a>
     <br/>
 {% endif %}
 {% if play_unselected %}
-    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected Instruments</a>
+    <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ full_score_midis.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected Instruments</a>
     <br/>
 {% endif %}
 <br/>
 <b>Instrument MIDIs</b><br/>
 {% for index, ins in full_score_midis.selected_instruments_midis.items() %}
-    <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} </a><br/>
+    <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} </a><br/>
     <li style="margin-left:15px; list-style-type:none;">
         {% for midipart in ins.midi_parts %}
-            <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+            <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
         {% endfor %}
     </li>
 {% endfor %}
@@ -52,51 +68,66 @@
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
+    Tempo:
+    <select class="ddlTempo" name="tempo">
+        <option value="50">50%</option>
+        <option value="100">100%</option>
+        <option value="150">150%</option>
+    </select>
+    &nbsp; &nbsp;
+    Click:
+    <select class="ddlClick" name="click">
+        <option value="n">None</option>
+        <option value="ba">Bars</option>
+        <option value="be">Beats</option>
+        <option value="qe">Eighth notes / Quavers</option>
+    </select>
+    <br/>
     {% if play_all %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
+        <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     {% if play_selected %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
+        <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ segment.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     {% if play_unselected %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
+        <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     <br/>
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
-        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a><br/>
+        <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a><br/>
         <li style="margin-left:15px; list-style-type:none;">
             {% for midipart in ins.midi_parts %}
-                <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+                <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
             {% endfor %}
         </li>
     {% endfor %}
     <br/>
 
-    {#  Loop over each bar pulling out the beat-based dictionaries #}
-    {% for bar, events_for_beats in segment.events_by_bar_and_beat|dictsort %}
-        {% if not loop.first %}<br/><br/>{% endif %}
-        <h3>Bar: {{ bar }}</h3>
 
-        {#  Loop over each beat pulling out the hand-based dictionaries #}
-        {% for beat, events_per_hand in events_for_beats.items() %}
-            {# {% if not loop.first %}<br/>{% endif %}#}
-            <div>Beat {{ beat | int  }}:
-            {#  Loop over each hand #}
-            {% for hand in ('Both', 'Left', 'Right', 'BothAfter') %}
-                {#  Create a dict to store the previous value (a plain variable has problems with scope) #}
-                {% set previous_event = {'value' : None} %}
-                {#  Loop over each hand #}
-                {# Are there are events in this hand? #}
-                {% if hand in events_per_hand.keys() %}
-                    <div>
-                    {# Yes, only output the name of the hand if it's not Both or BothAfter #}
-                    {% if hand not in ('Both', 'BothAfter') %}{{ hand }} hand:{% endif %}
-                    {#  Pull out the event arrays for each pitch index #}
-                    {% for voice, events_per_voice in events_per_hand[hand]|dictsort|reverse %}
+    {% for instrument_index, description in segment.selected_instruments_descriptions.items() %}
+        {% if segment.selected_instruments_descriptions|length > 1 %}
+            <h2>{{instruments[instrument_index][0]}}</h2>
+        {% endif %}
+        {% for part_description in description %}
+            {% if description|length > 1 %}
+                <h3>{{part_names[instruments[instrument_index][1] + loop.index-1 ]}}</h3>
+            {% endif %}
+            {#  Loop over each bar pulling out the beat-based dictionaries #}
+            {% for bar, events_for_beats in part_description.items() %}
+                {% if not loop.first %}<br/>{% endif %}
+                <h3>Bar: {{ bar }}</h3>
+
+                {#  Loop over each beat pulling out the hand-based dictionaries #}
+                {% for beat, events_per_hand in events_for_beats.items() %}
+                    {# {% if not loop.first %}<br/>{% endif %}#}
+                    <div>Beat {{ beat | int  }}:
+                    {% set previous_event = {'value' : None} %}
+                    {#  Loop over each hand #}
+                    {% for voice, events_per_voice in events_per_hand|dictsort|reverse %}
                         {% if not loop.first %} together with {% endif %}
                         {% for pitch_space, events in events_per_voice.items() %}
                             {% if not loop.first %}, {% endif %}
@@ -108,12 +139,14 @@
                             {% endfor %} {# End loop over events #}
                         {% endfor %} {# End loop over pitch indexes #}
                     {% endfor %}. {# End loop over voices #}
+            
                     </div>
-                {% endif %} {# End test for existence of hand-specific dictionary #}
-            {% endfor %} {# End loop over hands indexes #}
-            </div>
-        {% endfor %} {# End loop over beats #}
-     {% endfor %} {# End loop over bars #}
+                {% endfor %} {# End loop over beats #}                    
+            {% endfor %} {# End loop over bars #}
+
+
+        {% endfor %}
+    {% endfor %}
 
 {% endfor %}
 
@@ -137,5 +170,28 @@
 {#    };#}
 {##}
 {#</script>#}
+
+<script>
+    $(document).ready(function() {
+        $(".ddlTempo").on('change', function (event) {
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            let newTempo = this.value
+            let click = $("#ddlClick").val()
+            $('.lnkPlay').each(function(i, obj) {
+                let href=$(this).attr('onClick');
+                console.log(href)
+                let posTempo = href.indexOf('&t=')
+                href = href.substr(0,posTempo)
+                $(this).attr('onClick', href +"&t="+ newTempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
+            });
+
+            $('.ddlTempo').each(function(ddlIndex, ddlObj) {
+                ddlObj.value=newTempo
+            });
+
+        });
+    });
+</script>
 </body>
 </html>

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -43,6 +43,11 @@
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
         <a href="#" onClick="MIDIjs.play('{{ ins.midi }}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
+        <li style="margin-left:15px; list-style-type:none;">
+            {% for midipart in ins.midi_parts %}
+                <a href="#" onClick="MIDIjs.play('{{ midipart }}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+            {% endfor %}
+        </li>
     {% endfor %}
     <br/><br/>
 
@@ -53,7 +58,7 @@
 
         {#  Loop over each beat pulling out the hand-based dictionaries #}
         {% for beat, events_per_hand in events_for_beats.items() %}
-{#            {% if not loop.first %}<br/>{% endif %}#}
+{#          {% if not loop.first %}<br/>{% endif %}#}
             <div>Beat {{ beat | int  }}:
             {#  Loop over each hand #}
             {% for hand in ('Both', 'Left', 'Right', 'BothAfter') %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -134,7 +134,7 @@ Click:
                 {#  Loop over each beat pulling out the hand-based dictionaries #}
                 {% for beat, events_per_hand in events_for_beats.items() %}
                     {# {% if not loop.first %}<br/>{% endif %}#}
-                    <div>Beat {{ beat | int  }}:
+                    <div>Beat {{ beat }}:
                     {% set previous_event = {'value' : None} %}
                     {#  Loop over each hand #}
                     {% for voice, events_per_voice in events_per_hand|dictsort|reverse %}
@@ -143,6 +143,7 @@ Click:
                             {% if not loop.first %}, {% endif %}
                             {#  Loop over the events  #}
                             {% for event in events %}
+                                {% if not loop.first %}, {% endif %}
                                 {{ event.render(previous_event['value'])|join(' ') }}
                                 {#  Store the event for context next time around  #}
                                 {% set _ = previous_event.update({'value': event}) %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -64,6 +64,7 @@ Click:
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
 
 <h1>Summary:</h1>
+{{general_summary}}
 {% for summary in parts_summary %}
     <h3>{{selected_part_names[loop.index-1]}}</h3>
     {{summary}}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -48,8 +48,8 @@ Click:
     <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ full_score_midis.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected Instruments</a>
     <br/>
 {% endif %}
-<br/>
-<b>Instrument MIDIs</b><br/>
+
+<h3>Instrument MIDIs</h3>
 {% for index, ins in full_score_midis.selected_instruments_midis.items() %}
     <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} </a><br/>
     <li style="margin-left:15px; list-style-type:none;">
@@ -58,11 +58,21 @@ Click:
         {% endfor %}
     </li>
 {% endfor %}
-<br/>
 
-<h2>Stop Music Playback</h2>
+
+<h1>Stop Music Playback</h1>
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
 
+<h1>Summary:</h1>
+{% for summary in parts_summary %}
+    <h3>{{selected_part_names[loop.index-1]}}</h3>
+    {{summary}}
+    <br/>
+{% endfor %}
+<br/>
+
+
+<h1>Music segment descriptions and playback</h1>
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
@@ -92,7 +102,7 @@ Click:
         <br/>
     {% endif %}
     <br/>
-    <b>Instrument MIDIs</b><br/>
+    <h3>Instrument MIDIs</h3><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
         <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a><br/>
         <li style="margin-left:15px; list-style-type:none;">
@@ -106,7 +116,7 @@ Click:
 
     {% for instrument_index, description in segment.selected_instruments_descriptions.items() %}
         {% if segment.selected_instruments_descriptions|length > 1 %}
-            <h2>{{instruments[instrument_index][0]}}</h2>
+            <h3>{{instruments[instrument_index][0]}}</h3>
         {% endif %}
         {% for part_description in description %}
             {% if description|length > 1 %}
@@ -115,7 +125,7 @@ Click:
             {#  Loop over each bar pulling out the beat-based dictionaries #}
             {% for bar, events_for_beats in part_description.items() %}
                 {% if not loop.first %}<br/>{% endif %}
-                <h3>Bar: {{ bar }}</h3>
+                <h4>Bar: {{ bar }}</h4>
 
                 {#  Loop over each beat pulling out the hand-based dictionaries #}
                 {% for beat, events_per_hand in events_for_beats.items() %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -145,7 +145,7 @@ Click:
                     {% set previous_event = {'value' : None} %}
                     {#  Loop over each hand #}
                     {% for voice, events_per_voice in events_per_beat|dictsort %}
-                        {% if not loop.first %} together with {% endif %}
+                        {% if not loop.first %} - together with {% endif %}
                         {% for pitch_space, events in events_per_voice.items() %}
                             {% if not loop.first %}, {% endif %}
                             {#  Loop over the events  #}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -21,35 +21,53 @@
 <p>Time signature of {{ preamble['time_signature'] }}, key signature of {{ preamble['key_signature'] }}, tempo of {{ preamble['tempo']|default('no tempo specified') }}</p>
 <p>Music, both hands, a bar at a time, beat by beat</p>
 
-<a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Play entire score</a><br/>
-
-{% if settings['playSelected'] == True %}
-    <a href="#" onClick="MIDIjs.play('{{ full_score_selected }}'); return false;">Play entire score (selected parts)</a><br/>    
+<h2>Entire score:</h2>
+{% if play_all %}
+    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All Instruments </a>
+    <br/>
 {% endif %}
-{% if settings['playUnselected'] == True %}
-    <a href="#" onClick="MIDIjs.play('{{ full_score_unselected }}'); return false;">Play entire score (unselected parts)</a><br/>    
-{% endif %}    
+{% if play_selected %}
+    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected Instruments </a>
+    <br/>
+{% endif %}
+{% if play_unselected %}
+    <a href="#" onClick="MIDIjs.play('{{ full_score_midis.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected Instruments</a>
+    <br/>
+{% endif %}
+<br/>
+<b>Instrument MIDIs</b><br/>
+{% for index, ins in full_score_midis.selected_instruments_midis.items() %}
+    <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} </a><br/>
+    <li style="margin-left:15px; list-style-type:none;">
+        {% for midipart in ins.midi_parts %}
+            <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+        {% endfor %}
+    </li>
+{% endfor %}
+<br/>
+
+<h2>Stop Music Playback</h2>
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
 
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
     {% if play_all %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     {% if play_selected %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_sel + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Selected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     {% if play_unselected %}
-        <a href="#" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a>
+        <a href="#" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
     <br/>
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
-        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
+        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a><br/>
         <li style="margin-left:15px; list-style-type:none;">
             {% for midipart in ins.midi_parts %}
                 <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -9,7 +9,11 @@
     <script type='text/javascript' src='//www.midijs.net/lib/midi.js'></script> 
 {#   <!-- extras -->#}
     <style type="text/css">
-        body{font-family: Georgia; font-size: 16pt}
+        body{font-family: Georgia; font-size: 26pt}
+        
+        h4 {
+            margin-block-end:1rem;
+        }
     </style>
 </head>
 <body>
@@ -22,19 +26,20 @@
 <p>Music, both hands, a bar at a time, beat by beat</p>
 
 <h2>Entire score:</h2>
-Tempo:
-<select class="ddlTempo" name="tempo" id="ddlTempo">
-    <option value="50">50%</option>
-    <option value="100" selected>100%</option>
-    <option value="150">150%</option>
-</select>
-&nbsp; &nbsp;
-Click:
-<select class="ddlClick" name="click" id="ddlClick">
-    <option value="n">None</option>
-    <option value="be">Bars / Beats</option>
-</select>
-<br/>
+<p>
+    Tempo:
+    <select class="ddlTempo" name="tempo" id="ddlTempo">
+        <option value="50">50%</option>
+        <option value="100" selected>100%</option>
+        <option value="150">150%</option>
+    </select>
+    &nbsp; &nbsp;
+    Click:
+    <select class="ddlClick" name="click" id="ddlClick">
+        <option value="n">None</option>
+        <option value="be">Bars / Beats</option>
+    </select>
+</p>
 {% if play_all %}
     <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ full_score_midis.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All Instruments </a>
     <br/>
@@ -76,19 +81,20 @@ Click:
 {% for segment in music_segments %}
 
     <h2>Bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}</h2>
-    Tempo:
-    <select class="ddlTempo" name="tempo">
-        <option value="50">50%</option>
-        <option value="100" selected>100%</option>
-        <option value="150">150%</option>
-    </select>
-    &nbsp; &nbsp;
-    Click:
-    <select class="ddlClick" name="click">
-        <option value="n">None</option>
-        <option value="be">Bars / Beats</option>
-    </select>
-    <br/>
+    <p>
+        Tempo:
+        <select class="ddlTempo" name="tempo">
+            <option value="50">50%</option>
+            <option value="100" selected>100%</option>
+            <option value="150">150%</option>
+        </select>
+        &nbsp; &nbsp;
+        Click:
+        <select class="ddlClick" name="click">
+            <option value="n">None</option>
+            <option value="be">Bars / Beats</option>
+        </select>
+    </p>
     {% if play_all %}
         <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ segment.midi_all + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play All - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
@@ -101,8 +107,8 @@ Click:
         <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ segment.midi_un + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play Unselected - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a>
         <br/>
     {% endif %}
-    <br/>
-    <h3>Instrument MIDIs</h3><br/>
+    
+    <h3>Instrument MIDIs</h3>
     {% for index, ins in segment.selected_instruments_midis.items() %}
         <a href="#" class="lnkPlay" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}{{"&bpi="}}{{binary_play_all}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %} </a><br/>
         <li style="margin-left:15px; list-style-type:none;">

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -119,6 +119,7 @@ Click:
             <h3>{{instruments[instrument_index][0]}}</h3>
         {% endif %}
         {% for part_description in description %}
+            {% set part_index = loop.index0 %}
             {% if description|length > 1 %}
                 <h3>{{part_names[instruments[instrument_index][1] + loop.index-1 ]}}</h3>
             {% endif %}
@@ -126,8 +127,8 @@ Click:
             {% for bar, events_for_beats in part_description.items() %}
                 {#% if not loop.first %}<br/>{% endif %#}
                 <h4>Bar: {{ bar }}</h4>
-                {% if bar in repetition_in_contexts[instrument_index] %}
-                    Repetition - {{repetition_in_contexts[instrument_index][bar]}} 
+                {% if bar in repetition_in_contexts[instruments[instrument_index][1] + part_index] %}
+                    Repetition - {{repetition_in_contexts[instruments[instrument_index][1] + part_index][bar]}} 
                     <br/> <br/>
                 {% endif %}
 

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -38,10 +38,10 @@
     <br/><br/>
     <b>Instrument MIDIs</b><br/>
     {% for index, ins in segment.selected_instruments_midis.items() %}
-        <a href="#" onClick="MIDIjs.play('{{ ins.midi }}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
+        <a href="#" onClick="MIDIjs.play('{{ ins.midi + "&bsi="}}{{binary_selected_instruments}}'); return false;">Play - {{instruments[ins.ins][0]}} - bar{% if segment.start_bar != segment.end_bar %}s{% endif %} {{ segment.start_bar }} {% if segment.start_bar != segment.end_bar %} to {{ segment.end_bar }}{% endif %}, </a><br/>
         <li style="margin-left:15px; list-style-type:none;">
             {% for midipart in ins.midi_parts %}
-                <a href="#" onClick="MIDIjs.play('{{ midipart }}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
+                <a href="#" onClick="MIDIjs.play('{{ midipart + "&bsi="}}{{binary_selected_instruments}}'); return false;">{{part_names[instruments[ins.ins][1] + loop.index-1 ]}}  </a><br/>
             {% endfor %}
         </li>
     {% endfor %}

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -33,9 +33,7 @@ Tempo:
 Click:
 <select class="ddlClick" name="click" id="ddlClick">
     <option value="n">None</option>
-    <option value="ba">Bars</option>
-    <option value="be">Beats</option>
-    <option value="qe">Eighth notes / Quavers</option>
+    <option value="be">Bars / Beats</option>
 </select>
 <br/>
 {% if play_all %}
@@ -78,9 +76,7 @@ Click:
     Click:
     <select class="ddlClick" name="click">
         <option value="n">None</option>
-        <option value="ba">Bars</option>
-        <option value="be">Beats</option>
-        <option value="qe">Eighth notes / Quavers</option>
+        <option value="be">Bars / Beats</option>
     </select>
     <br/>
     {% if play_all %}
@@ -176,18 +172,37 @@ Click:
         $(".ddlTempo").on('change', function (event) {
             event.stopPropagation();
             event.stopImmediatePropagation();
-            let newTempo = this.value
+            let tempo = this.value
             let click = $("#ddlClick").val()
             $('.lnkPlay').each(function(i, obj) {
                 let href=$(this).attr('onClick');
-                console.log(href)
                 let posTempo = href.indexOf('&t=')
                 href = href.substr(0,posTempo)
-                $(this).attr('onClick', href +"&t="+ newTempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
+                $(this).attr('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
             });
 
             $('.ddlTempo').each(function(ddlIndex, ddlObj) {
-                ddlObj.value=newTempo
+                ddlObj.value=tempo
+            });
+
+        });
+    });
+
+    $(document).ready(function() {
+        $(".ddlClick").on('change', function (event) {
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            let click = this.value
+            let tempo = $("#ddlTempo").val()
+            $('.lnkPlay').each(function(i, obj) {
+                let href=$(this).attr('onClick');
+                let posTempo = href.indexOf('&t=')
+                href = href.substr(0,posTempo)
+                $(this).attr('onClick', href +"&t="+ tempo + "&c=" + click + "&bsi={{binary_selected_instruments}}&bpi={{binary_play_all}}'); return false;") 
+            });
+
+            $('.ddlClick').each(function(ddlIndex, ddlObj) {
+                ddlObj.value=click
             });
 
         });

--- a/lib/talkingscore.html
+++ b/lib/talkingscore.html
@@ -22,6 +22,13 @@
 <p>Music, both hands, a bar at a time, beat by beat</p>
 
 <a href="#" onClick="MIDIjs.play('{{ full_score }}'); return false;">Play entire score</a><br/>
+
+{% if settings['playSelected'] == True %}
+    <a href="#" onClick="MIDIjs.play('{{ full_score_selected }}'); return false;">Play entire score (selected parts)</a><br/>    
+{% endif %}
+{% if settings['playUnselected'] == True %}
+    <a href="#" onClick="MIDIjs.play('{{ full_score_unselected }}'); return false;">Play entire score (unselected parts)</a><br/>    
+{% endif %}    
 <a href="#" onClick="MIDIjs.stop(); return false;">Stop playback</a>
 
 {% for segment in music_segments %}

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -138,6 +138,18 @@ class TSPitch(TSEvent):
             return ""
 
 
+class TSUnpitched(TSEvent):
+    pitch = None
+
+    def render(self, context=None):
+        rendered_elements = []
+        # Render the duration
+        rendered_elements.append(' '.join(super(TSUnpitched, self).render(context)))
+        # Render the pitch
+        rendered_elements.append(' unpitched')
+        return rendered_elements
+
+
 class TSRest(TSEvent):
     pitch = None
 
@@ -528,6 +540,9 @@ class Music21TalkingScore(TalkingScoreBase):
                     event.tie = element.tie.type
 
                 event.expressions = element.expressions
+            elif element_type == 'Unpitched':
+                event = TSUnpitched()
+                description_order = 1
             elif element_type == 'Rest':
                 event = TSRest()
                 description_order = 1

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -294,11 +294,16 @@ class Music21TalkingScore(TalkingScoreBase):
     def get_initial_time_signature(self):
         # Get the first measure of the first part
         m1 = self.score.parts[0].measures(1, 1)
-        initial_time_signature = m1.getTimeSignatures()[0]
+        initial_time_signature = None
+        if (len(self.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)) > 0):
+            initial_time_signature = self.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)[0]
         return self.describe_time_signature(initial_time_signature)
 
     def describe_time_signature(self, ts):
-        return " ".join(ts.ratioString.split("/"))
+        if ts != None:
+            return " ".join(ts.ratioString.split("/"))
+        else:
+            return " error reading time signature...  "
 
     def get_initial_key_signature(self):
         m1 = self.score.parts[0].measures(1, 1)
@@ -922,7 +927,7 @@ class HTMLTalkingScoreFormatter():
             self.time_and_keys.setdefault(ks.measureNumber, []).append(description)
 
         self.score.timeSigs = {}  # key=bar number.  Value = timeSig
-        previous_ts = self.score.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)[0]
+        previous_ts = self.score.score.parts[0].getElementsByClass('Measure')[0].getTimeSignatures()[0]
 
         # pickup bar
         if self.score.score.parts[0].getElementsByClass('Measure')[0].number != self.score.score.parts[0].measures(1, 2).getElementsByClass('Measure')[0].number:

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -959,6 +959,9 @@ class HTMLTalkingScoreFormatter():
             while (end_bar_index >= 1 and self.score.score.parts[0].measure(end_bar_index+1) == None):
                 end_bar_index = end_bar_index - 1
                 print("end bar index was too big - now " + str(end_bar_index))
+            # if there is only 1 bar - and it isn't a pickup bar
+            if end_bar_index == 0 and self.score.score.parts[0].measure(0) == None:
+                end_bar_index = 1
             for checkts in range(bar_index, end_bar_index+1):
                 if (self.score.score.parts[0].measure(bar_index) == None):
                     print("bar " + str(bar_index) + " is None...")

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -368,7 +368,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 last  = spanner.getLast()
                 if first.measureNumber is None or last.measureNumber is None:
                     continue
-                pitch_index = 0
+                description_order = 0
                 voice = 1
 
                 if first.measureNumber >= start_bar and first.measureNumber <= end_bar:
@@ -378,7 +378,7 @@ class Music21TalkingScore(TalkingScoreBase):
                         .setdefault(math.floor(first.beat), {})\
                         .setdefault('Both', {})\
                         .setdefault(voice, {})\
-                        .setdefault(pitch_index, [])\
+                        .setdefault(description_order, [])\
                         .append(event)
 
                 if last.measureNumber >= start_bar and last.measureNumber <= end_bar:
@@ -389,12 +389,12 @@ class Music21TalkingScore(TalkingScoreBase):
                         .setdefault(math.floor(last.beat) + last.duration.quarterLength - 1, {})\
                         .setdefault('BothAfter', {})\
                         .setdefault(voice, {})\
-                        .setdefault(pitch_index, [])\
+                        .setdefault(description_order, [])\
                         .append(event)
 
         measures = self.score.measures(start_bar, end_bar)
         for part in measures.parts:
-            print("Processing part %s, bars %s to %s" % (part.id, start_bar, end_bar))
+            print("\n\nProcessing part %s, bars %s to %s" % (part.id, start_bar, end_bar))
             # Iterate over the bars one at a time
             # pickup bar has to request measures 0 to 1 above otherwise it returns an measures just has empty parts - so now restrict it just to bar 0...
             if start_bar==0 and end_bar==1:
@@ -416,25 +416,25 @@ class Music21TalkingScore(TalkingScoreBase):
             if element_type == 'Note':
                 event = TSNote()
                 event.pitch = TSPitch( self.map_pitch(element.pitch), self.map_octave(element.pitch.octave), element.pitch.ps, element.pitch.name[0] )
-                pitch_index = element.pitch.ps
+                description_order = 1
                 if element.tie:
                     event.tie = element.tie.type
  
                 event.expressions = element.expressions
             elif element_type == 'Rest':
                 event = TSRest()
-                pitch_index = 0
+                description_order = 1
                 
             elif element_type == 'Chord':
                 event = TSChord()
                 event.pitches = [ TSPitch(self.map_pitch(element_pitch), self.map_octave(element_pitch.octave), element_pitch.ps, element_pitch.name[0]) for element_pitch in element.pitches ]
-                pitch_index = element.bass().ps # Take the bottom note of the chord for ordering
+                description_order = 1
                 if element.tie:
                     event.tie = element.tie.type
 
             elif element_type == 'Dynamic':
                 event = TSDynamic(long_name = element.longName, short_name=element.value)
-                pitch_index = 0 # Always speak the dynamic first
+                description_order = 0 # Always speak the dynamic first
                 hand = 'Both'
 
             elif element_type == 'Voice':
@@ -457,7 +457,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 .setdefault(math.floor(element.beat), {})\
                 .setdefault(hand, {})\
                 .setdefault(voice, {})\
-                .setdefault(pitch_index, [])\
+                .setdefault(description_order, [])\
                 .append(event)
 
 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -370,7 +370,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 else:
                     self.part_names[c] = "Part " + str(self.part_instruments[ins_count-1][2])
 
-        print("part_instruments = " + str(self.part_instruments))
+        logger.debug(f"part instruments = {self.part_instruments}")
         print("part names = " + str(self.part_names))
         print("instrument names = " + str(instrument_names))
         return instrument_names 
@@ -443,8 +443,7 @@ class Music21TalkingScore(TalkingScoreBase):
         if measures.measure(start_bar)!=None and len(measures.measure(start_bar).getElementsByClass(meter.TimeSignature))==0:
             measures.measure(start_bar).insert(0, self.timeSigs[start_bar])
 
-        print("\n\nProcessing part %s, bars %s to %s" % (part_index, start_bar, end_bar))
-        
+        logger.info(f'Processing part - {part_index} - bars {start_bar} to {end_bar}')
         # Iterate over the bars one at a time
         # pickup bar has to request measures 0 to 1 above otherwise it returns an measures just has empty parts - so now restrict it just to bar 0...
         if start_bar==0 and end_bar==1:

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -130,6 +130,13 @@ class Music21TalkingScore(TalkingScoreBase):
         7: 'top'
     }
 
+    _DOTS_MAP = {
+        0 : '',
+        1 : 'dotted ',
+        2 : 'double dotted ',
+        3 : 'triple dotted '
+    }
+
     _DURATION_MAP = {
         'whole': 'semibreve',
         'half': 'minim',
@@ -331,8 +338,7 @@ class Music21TalkingScore(TalkingScoreBase):
 
             # This test isn't WORKING
             # if TSEvent.__class__ in event.__class__.__bases__:
-            event.duration = self.map_duration(element.duration)
-
+            event.duration = self.map_dots(element.duration.dots) + self.map_duration(element.duration)
             events\
                 .setdefault(measure.measureNumber, {})\
                 .setdefault(math.floor(element.beat), {})\
@@ -429,7 +435,8 @@ class Music21TalkingScore(TalkingScoreBase):
     def map_duration(self, duration):
         return self._DURATION_MAP.get(duration.type, 'Unknown duration %s'%duration.type)
 
-
+    def map_dots(self, dots):
+        return self._DOTS_MAP.get(dots)
 
 class HTMLTalkingScoreFormatter():
 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -281,7 +281,10 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def get_initial_key_signature(self):
         m1 = self.score.parts[0].measures(1,1)
-        ks = m1.flat.getElementsByClass('KeySignature')[0]
+        if len(m1.flat.getElementsByClass('KeySignature'))==0:
+            ks = key.KeySignature(0)
+        else:
+            ks = m1.flat.getElementsByClass('KeySignature')[0]
         return self.describe_key_signature(ks)
 
     def describe_key_signature(self, ks):

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -730,19 +730,22 @@ class HTMLTalkingScoreFormatter():
         print ("Settings...")
         print (settings)
         
-        full_score_selected = ""
-        if settings['playSelected']==True:
-            full_score_selected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, sel="sel")
-        full_score_unselected = ""
-        if settings['playUnselected']==True:
-            full_score_unselected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, sel="un")
+        start = self.score.score.parts[0].getElementsByClass('Measure')[0].number
+        end = self.score.score.parts[0].getElementsByClass('Measure')[-1].number
+        selected_instruments_midis = {}
+        for index, ins in enumerate(self.score.selected_instruments):
+            midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=start, range_end=end, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
+            selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
+        
+        midiAll = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="all")
+        midiSelected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="sel")
+        midiUnselected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="un")
+        full_score_midis = {'selected_instruments_midis':selected_instruments_midis, 'midi_all':midiAll, 'midi_sel':midiSelected, 'midi_un':midiUnselected }
         
         return template.render({'settings' : settings,
                                 'basic_information': self.get_basic_information(),
                                 'preamble': self.get_preamble(),
-                                'full_score': "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(self.score.generate_midi_for_part_range(output_path=output_path)),
-                                'full_score_selected': "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(full_score_selected),
-                                'full_score_unselected': "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(full_score_unselected),
+                                'full_score_midis': full_score_midis,
                                 'music_segments': self.get_music_segments(output_path,web_path, ),
                                 'instruments' : self.score.part_instruments,
                                 'part_names' : self.score.part_names,

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -484,7 +484,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 for pi in range (self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
                     if self.part_instruments[ins][2]>1:
                         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-                        midi_filename = os.path.join(output_path, "%s%s.mid?part=%s" % ( base_filename, postfix_filename, str((pi-self.part_instruments[ins][1])+1) ) )
+                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&start=%d&end=%d" % ( base_filename, pi, range_start, range_end ) )
                         part_midis.append(midi_filename)
 
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -324,13 +324,26 @@ class Music21TalkingScore(TalkingScoreBase):
             settings['rhythmDescription'] = "british"
         return self.describe_tempo(self.score.metronomeMarkBoundaries()[0][2])
 
+    # some tempos have soundingNumber set but not number
+    # we would get an error trying to scale a tempo.number of None
+    # static so that it can be called by eg midiHandler when scaling tempos
+    @staticmethod
+    def fix_tempo_number(tempo):
+        if (tempo.number == None):
+            if (tempo.numberSounding != None):
+                tempo.number = tempo.numberSounding
+            else:
+                tempo.number = 120
+                tempo.text = "Error - " + tempo.text
+        return tempo
+
     def describe_tempo(self, tempo):
         tempo_text = ""
+        tempo = self.fix_tempo_number(tempo)
         if (tempo.text != None):
             tempo_text += tempo.text + " (" + str(math.floor(tempo.number)) + " bpm @ " + self.describe_tempo_referent(tempo) + ")"
         else:
             tempo_text += str(math.floor(tempo.number)) + " bpm @ " + self.describe_tempo_referent(tempo)
-        print(text)
         return tempo_text
 
     # the referent is the beat duration ie are you counting crotchets or minims etc

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -207,14 +207,18 @@ class Music21TalkingScore(TalkingScoreBase):
         return len(self.score.parts[0].getElementsByClass('Measure'))
 
     def get_instruments(self):
-        #instrument.Name = eg Piano, instrument.partId = 1.  A piano has 2 staves ie two parts with the same name and same ID.  But if you have a second piano, it will have the same name but a different partId
+        #eg instrument.Name = Piano, instrument.partId = 1.  A piano has 2 staves ie two parts with the same name and same ID.  But if you have a second piano, it will have the same name but a different partId
         self.part_instruments={} # key = instrument (1 based), value = ["part name", 1st part, number of parts, instrument.partId] 
         instrument_names=[] #still needed for Info / Options page
         ins_count = 1
         for c, instrument in enumerate(self.score.flat.getInstruments()):
             if len(self.part_instruments) == 0 or self.part_instruments[ins_count-1][3] != instrument.partId:
-                self.part_instruments[ins_count] = [instrument.partName, c, 1, instrument.partId]
-                instrument_names.append(instrument.partName)
+                pname = instrument.partName
+                if pname==None:
+                    pname = "Instrument  " + str(ins_count) + " (unnamed)"
+                self.part_instruments[ins_count] = [pname, c, 1, instrument.partId]
+                instrument_names.append(pname)
+                
                 ins_count+=1
             else:
                 self.part_instruments[ins_count-1][2]+=1

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -227,6 +227,16 @@ class Music21TalkingScore(TalkingScoreBase):
         'B': 'green',
     }
 
+    _PITCH_PHONETIC_MAP = {
+        'C': 'charlie',
+        'D': 'bravo',
+        'E': 'echo',
+        'F': 'foxtrot',
+        'G': 'golf',
+        'A': 'alpha',
+        'B': 'bravo',
+    }
+
     last_tempo_inserted_index = 0 # insert_tempos() doesn't need to recheck MetronomeMarkBoundaries that have already been used
     music_analyser = None;
 
@@ -533,6 +543,8 @@ class Music21TalkingScore(TalkingScoreBase):
             pitch_name = pitch.name[0]
         elif settings['pitchDescription']=="none":
             pitch_name = ""
+        elif settings['pitchDescription']=="phonetic":
+            pitch_name = self._PITCH_PHONETIC_MAP.get(pitch.name[0], "?")
         
         if pitch.accidental and pitch.accidental.displayStatus and pitch_name!="":
             pitch_name = "%s %s" % (pitch_name, pitch.accidental.fullName)

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -405,7 +405,11 @@ class HTMLTalkingScoreFormatter():
             'pitchBeforeDuration': False,
             'describeBy': 'beat',
             'handsTogether': True,
-            'barsAtATime': int(options["bars_at_a_time"])
+            'barsAtATime': int(options["bars_at_a_time"]),
+            'playAll':options["play_all"],
+            'playSelected':options["play_selected"],
+            'playUnselected':options["play_unselected"],
+            'instruments':options["instruments"],
         }
 
     def generateHTML(self,output_path="",web_path=""):

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -442,6 +442,7 @@ class Music21TalkingScore(TalkingScoreBase):
         return events_by_bar
 
     def update_events_for_measure(self, measure, events, voice:int=1):
+        previous_beat = 1
         for element in measure.elements:
             element_type = type(element).__name__
             event = None
@@ -483,10 +484,18 @@ class Music21TalkingScore(TalkingScoreBase):
             event.duration += self.map_duration(element.duration)
             if settings['dotPosition']=="after":
                 event.duration += " " + self.map_dots(element.duration.dots)
+            
+            if (math.floor(element.beat)==math.floor(previous_beat)): # eg was 1 now 1.5 ie same beat
+                beat = previous_beat
+            elif (math.floor(element.beat)==element.beat): # was 1.5 now 2.0 - ie start of a new beat
+                beat = math.floor(element.beat) # strip off the point 0
+            else: # eg was 1 now 2.5 ie part way through a new beat - mention decimal
+                beat = element.beat
+            previous_beat = beat
 
             events\
                 .setdefault(measure.measureNumber, {})\
-                .setdefault(math.floor(element.beat), {})\
+                .setdefault(beat, {})\
                 .setdefault(voice, {})\
                 .setdefault(description_order, [])\
                 .append(event)

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -882,7 +882,6 @@ class HTMLTalkingScoreFormatter():
         if self.score.score.parts[0].getElementsByClass('Measure')[0].number != self.score.score.parts[0].measures(1,2).getElementsByClass('Measure')[0].number:
             previous_ts = self.score.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)[0]
             self.score.timeSigs[0] = previous_ts
-            time_sig_index+=1
             #todo - where should spanners and dynamics etc go?
             selected_instruments_descriptions = {} # key = instrument index, {[part descriptions]} 
             
@@ -904,8 +903,19 @@ class HTMLTalkingScoreFormatter():
             end_bar_index = bar_index + settings['barsAtATime'] - 1
             if end_bar_index > number_of_bars:
                 end_bar_index = number_of_bars
+                
+            #cludge to not have None bars - but will actually ignore some...
+            #todo - we get the number of bars just by the length and use that as the maximum bar number.  However- sometimes bars are called "X1" for half bars next to a repeat.  Or Finale re-uses bar numbers for sections - so need a better way of getting each bar...
+            if (self.score.score.parts[0].measure(bar_index) == None):
+                print("start bar is none...")
+                break
+            while (end_bar_index>=1 and self.score.score.parts[0].measure(end_bar_index+1) == None):
+                end_bar_index = end_bar_index -1
+                print("end bar index was too big - now " + str(end_bar_index))
             for checkts in range(bar_index, end_bar_index+1):
-                if len(self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature))>0:
+                if (self.score.score.parts[0].measure(bar_index) == None):
+                    print ("bar " + str(bar_index) + " is None...")
+                elif len(self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature))>0:
                     previous_ts = self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature)[0]
                 self.score.timeSigs[checkts] = previous_ts
                 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -599,7 +599,7 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def map_pitch(self, pitch):
         global settings
-        if settings['pitchDescription']=="figureNotes":
+        if settings['pitchDescription']=="colourNotes":
             pitch_name = self._PITCH_FIGURENOTES_MAP.get(pitch.name[0], "?")
         if settings['pitchDescription']=="noteName":
             pitch_name = pitch.name[0]

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -375,7 +375,6 @@ class Music21TalkingScore(TalkingScoreBase):
         return bars_for_parts
 
     def get_events_for_bar_range(self, start_bar, end_bar, part_index):
-        #todo - I have broken multiple voices!
         events_by_bar = {}
         # Iterate over the spanners
         """ 
@@ -426,7 +425,7 @@ class Music21TalkingScore(TalkingScoreBase):
 
         return events_by_bar
 
-    def update_events_for_measure(self, measure, events, voice=1):
+    def update_events_for_measure(self, measure, events, voice:int=1):
         for element in measure.elements:
             element_type = type(element).__name__
             event = None
@@ -455,7 +454,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 
 
             elif element_type == 'Voice':
-                self.update_events_for_measure(element, events, element.id)
+                self.update_events_for_measure(element, events, int(element.id))
 
             if event is None:
                 continue

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -16,6 +16,7 @@ from abc import ABCMeta, abstractmethod
 from jinja2 import Template
 from datetime import datetime #start_time = datetime.now()
 logger = logging.getLogger("TSScore")
+import time
 
 global settings
 
@@ -428,7 +429,7 @@ class Music21TalkingScore(TalkingScoreBase):
                         .append(event)
         """
         
-        measures = self.score.parts[part_index].measures(start_bar, end_bar)
+        measures = self.score.parts[part_index].measures(start_bar, end_bar, collect=('TimeSignature'))
         print("\n\nProcessing part %s, bars %s to %s" % (part_index, start_bar, end_bar))
         # Iterate over the bars one at a time
         # pickup bar has to request measures 0 to 1 above otherwise it returns an measures just has empty parts - so now restrict it just to bar 0...
@@ -816,6 +817,8 @@ class HTMLTalkingScoreFormatter():
         logger.info("Start of get_music_segments")
         music_segments = []
         number_of_bars = self.score.get_number_of_bars()
+        
+        t1s = time.time()
         #pickup bar
         if self.score.score.parts[0].getElementsByClass('Measure')[0].number != self.score.score.parts[0].measures(1,2).getElementsByClass('Measure')[0].number:
             
@@ -862,7 +865,8 @@ class HTMLTalkingScoreFormatter():
             music_segments.append(music_segment)
 
         logger.info("End of get_music_segments")
-        
+        t1e = time.time()
+        print("described parts etc = " + str(t1e-t1s))
         return music_segments
 
 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -775,6 +775,7 @@ class HTMLTalkingScoreFormatter():
                                 'play_selected' : settings['playSelected'],
                                 'play_unselected' : settings['playUnselected'],
                                 'parts_summary' : self.music_analyser.summary_parts,
+                                'general_summary' : self.music_analyser.general_summary,
                                 'selected_part_names' : self.score.selected_part_names,
                                 })
 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -776,6 +776,7 @@ class HTMLTalkingScoreFormatter():
                                 'play_unselected' : settings['playUnselected'],
                                 'parts_summary' : self.music_analyser.summary_parts,
                                 'general_summary' : self.music_analyser.general_summary,
+                                'repetition_in_contexts' : self.music_analyser.repetition_in_contexts,
                                 'selected_part_names' : self.score.selected_part_names,
                                 })
 

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -265,9 +265,10 @@ class Music21TalkingScore(TalkingScoreBase):
             return self.score.metadata.title
         # Have a guess
         for tb in self.score.flat.getElementsByClass('TextBox'):
-            if tb.justify == 'center' and tb.alignVertical == 'top' and tb.size > 18:
+            # in some musicxml files - a textbox might not have those attributes - so we use hasattr()...
+            if hasattr(tb, 'justifty') and tb.justify == 'center' and hasattr(tb, 'alignVertical') and tb.alignVertical == 'top' and hasattr(tb, 'size') and tb.size > 18:
                 return tb.content
-        return "Unknown"
+        return "Error reading title"
 
     def get_composer(self):
         if self.score.metadata.composer != None:

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -65,7 +65,7 @@ class TSEvent(object, metaclass=ABCMeta):
         rendered_elements.append(self.endTuplets)
 
         if self.tie:
-            rendered_elements.append("tie %s" % self.tie)
+            rendered_elements.append(f"tie {self.tie}")
         return rendered_elements
 
 
@@ -173,7 +173,7 @@ class TSChord(TSEvent):
         return ''
 
     def render(self, context=None):
-        rendered_elements = ['%s-note chord' % len(self.pitches)]
+        rendered_elements = [f'{len(self.pitches)}-note chord']
         rendered_elements.append(' '.join(super(TSChord, self).render(context)))
         previous_pitch = None
         for pitch in sorted(self.pitches, key=lambda TSPitch: TSPitch.pitch_number):
@@ -481,7 +481,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 voice = 1
 
                 if first.measureNumber >= start_bar and first.measureNumber <= end_bar:
-                    event = TSDynamic(long_name='%s start' % spanner_type)
+                    event = TSDynamic(long_name=f'{spanner_type} start')
                     events_by_bar\
                         .setdefault(first.measureNumber, {})\
                         .setdefault(first.beat, {})\
@@ -490,7 +490,7 @@ class Music21TalkingScore(TalkingScoreBase):
                         .append(event)
 
                 if last.measureNumber >= start_bar and last.measureNumber <= end_bar:
-                    event = TSDynamic(long_name='%s end' % spanner_type)
+                    event = TSDynamic(long_name=f'{spanner_type} end')
                     # todo -  Note - THIS WILL NOT HANDLE CRESCENDOS/DIMINUENDOS THAT SPAN MEASURES
                     events_by_bar\
                         .setdefault(last.measureNumber, {})\
@@ -576,13 +576,12 @@ class Music21TalkingScore(TalkingScoreBase):
         return chord_pitches_by_octave
 
     # for all / selected / unselected
-
     def generate_midi_filename_sel(self, prefix, range_start=None, range_end=None, output_path="", sel=""):
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
         if (range_start != None):
-            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&start=%d&end=%d&t=100&c=n" % (base_filename, sel, range_start, range_end)))
+            midi_filename = os.path.join(output_path, f"{base_filename}.mid?sel={sel}&start={range_start}&end={range_end}&t=100&c=n")
         else:
-            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&t=100&c=n" % (base_filename, sel,)))
+            midi_filename = os.path.join(output_path, f"{base_filename}.mid?sel={sel}&t=100&c=n")
         return (prefix+os.path.basename(midi_filename))
 
     def generate_part_descriptions(self, instrument, start_bar, end_bar):
@@ -599,21 +598,21 @@ class Music21TalkingScore(TalkingScoreBase):
                 for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
                     if self.part_instruments[ins][2] > 1:
                         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&t=100&c=n" % (base_filename, pi))
+                        midi_filename = os.path.join(output_path, f"{base_filename}.mid?part={pi}&t=100&c=n")
                         part_midis.append(midi_filename)
         else:  # specific measures
             for ins in add_instruments:
                 for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
                     if self.part_instruments[ins][2] > 1:
                         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&start=%d&end=%d&t=100&c=n" % (base_filename, pi, range_start, range_end))
+                        midi_filename = os.path.join(output_path, f"{base_filename}.mid?part={pi}&start={range_start}&end={range_end}&t=100&c=n")
                         part_midis.append(midi_filename)
 
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
         if (range_start != None):
-            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&start=%d&end=%d&t=100&c=n" % (base_filename, ins, range_start, range_end)))
+            midi_filename = os.path.join(output_path, f"{base_filename}.mid?ins={ins}&start={range_start}&end={range_end}&t=100&c=n")
         else:
-            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&t=100&c=n" % (base_filename, ins,)))
+            midi_filename = os.path.join(output_path, f"{base_filename}.mid?ins={ins}&t=100&c=n")
         part_midis = [prefix + os.path.basename(s) for s in part_midis]
         return (prefix+os.path.basename(midi_filename), part_midis)
 
@@ -647,7 +646,7 @@ class Music21TalkingScore(TalkingScoreBase):
                     s.insert(pi_measures)
 
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-        midi_filename = os.path.join(output_path, "%s%s.mid" % (base_filename, postfix_filename))
+        midi_filename = os.path.join(output_path, f"{base_filename}{postfix_filename}.mid")
         # todo - might need to add in tempos if part 0 is not included
         if not os.path.exists(midi_filename):
             s.write('midi', midi_filename)
@@ -660,7 +659,7 @@ class Music21TalkingScore(TalkingScoreBase):
             s = stream.Score(id='temp')
             s.insert(self.score.parts[self.part_instruments[instrument][1]+part])
             base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % (base_filename, postfix_filename, str(part+1)))
+            midi_filename = os.path.join(output_path, f"{base_filename}{postfix_filename}_p{(part+1)}.mid")
             if not os.path.exists(midi_filename):
                 s.write('midi', midi_filename)
         else:  # specific measures
@@ -677,7 +676,7 @@ class Music21TalkingScore(TalkingScoreBase):
             s.insert(pi_measures)
 
             base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % (base_filename, postfix_filename, str(part+1)))
+            midi_filename = os.path.join(output_path, f"{base_filename}{postfix_filename}_p{(part+1)}.mid")
             if not os.path.exists(midi_filename):
                 s.write('midi', midi_filename)
         return midi_filename
@@ -687,7 +686,7 @@ class Music21TalkingScore(TalkingScoreBase):
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
         if range_start is None and range_end is None:
             # Export the whole score
-            midi_filename = os.path.join(output_path, "%s.mid" % (base_filename))
+            midi_filename = os.path.join(output_path, f"{base_filename}.mid")
             if not os.path.exists(midi_filename):
                 self.score.write('midi', midi_filename)
             return midi_filename
@@ -696,7 +695,7 @@ class Music21TalkingScore(TalkingScoreBase):
                 if p.id not in parts:
                     continue
 
-                midi_filename = os.path.join(output_path, "%s_p%s_%s_%s.mid" % (base_filename, p.id, range_start, range_end))
+                midi_filename = os.path.join(output_path, f"{base_filename}_p{p.id}_{range_start}_{range_end}.mid")
                 if not os.path.exists(midi_filename):
                     midi_stream = p.measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
                     if p != self.score.parts[0]:  # only part 0 has tempos
@@ -707,7 +706,7 @@ class Music21TalkingScore(TalkingScoreBase):
                     midi_stream.write('midi', midi_filename)
                 return midi_filename
         else:  # both hands
-            midi_filename = os.path.join(output_path, "%s_%s_%s.mid" % (base_filename, range_start, range_end))
+            midi_filename = os.path.join(output_path, f"{base_filename}_{range_start}_{range_end}.mid")
             if not os.path.exists(midi_filename):
                 midi_stream = self.score.measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
                 # music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
@@ -746,7 +745,7 @@ class Music21TalkingScore(TalkingScoreBase):
         elif settings['octaveDescription'] == "number":
             return str(octave)
 
-        # return "%s %s" % (self._PITCH_MAP.get(pitch[-1], ''), pitch[0] )
+        # return f"{self._PITCH_MAP.get(pitch[-1], '')} {pitch[0]}"
 
     def map_pitch(self, pitch):
         global settings
@@ -760,7 +759,7 @@ class Music21TalkingScore(TalkingScoreBase):
             pitch_name = self._PITCH_PHONETIC_MAP.get(pitch.name[0], "?")
 
         if pitch.accidental and pitch.accidental.displayStatus and pitch_name != "":
-            pitch_name = "%s %s" % (pitch_name, pitch.accidental.fullName)
+            pitch_name = f"{pitch_name} {pitch.accidental.fullName}"
         return pitch_name
 
     def map_duration(self, duration):
@@ -768,7 +767,7 @@ class Music21TalkingScore(TalkingScoreBase):
         if settings['rhythmDescription'] == "american":
             return duration.type
         elif settings['rhythmDescription'] == "british":
-            return self._DURATION_MAP.get(duration.type, 'Unknown duration %s' % duration.type)
+            return self._DURATION_MAP.get(duration.type, f'Unknown duration {duration.type}')
         elif settings['rhythmDescription'] == "none":
             return ""
 
@@ -978,4 +977,4 @@ if __name__ == '__main__':
     with open(testScoreOutputFilePath, "wb") as fh:
         fh.write(html)
 
-    os.system('open http://0.0.0.0:8000/static/data/%s' % os.path.basename(testScoreOutputFilePath))
+    os.system(f'open http://0.0.0.0:8000/static/data/{os.path.basename(testScoreOutputFilePath)}')

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -904,6 +904,7 @@ class HTMLTalkingScoreFormatter():
 
             selected_instruments_midis = {}
             for index, ins in enumerate(self.score.selected_instruments):
+                logger.debug(f"enumerate selected instruments... index = {index} and ins ={ins}")
                 midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=0, range_end=0, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
                 selected_instruments_midis[ins] = {"ins": ins,  "midi": midis[0], "midi_parts": midis[1]}
                 selected_instruments_descriptions[ins] = self.score.generate_part_descriptions(instrument=ins, start_bar=0, end_bar=1)
@@ -945,6 +946,7 @@ class HTMLTalkingScoreFormatter():
             selected_instruments_descriptions = {}  # key = instrument index,
             selected_instruments_midis = {}
             for index, ins in enumerate(self.score.selected_instruments):
+                logger.debug(f"adding to selected_instruments_descriptions - index = {index} and ins = {ins}")
                 midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=bar_index, range_end=end_bar_index, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
                 selected_instruments_midis[ins] = {"ins": ins,  "midi": midis[0], "midi_parts": midis[1]}
                 selected_instruments_descriptions[ins] = self.score.generate_part_descriptions(instrument=ins, start_bar=bar_index, end_bar=end_bar_index)

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -1,3 +1,7 @@
+from datetime import datetime  # start_time = datetime.now()
+import time
+from jinja2 import Template
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from jinja2.loaders import FileSystemLoader
 
@@ -7,18 +11,17 @@ import os
 import json
 import math
 import pprint
-import logging, logging.handlers, logging.config
+import logging
+import logging.handlers
+import logging.config
 from music21 import *
 from lib.musicAnalyser import *
 us = environment.UserSettings()
 us['warnings'] = 0
-from abc import ABCMeta, abstractmethod
-from jinja2 import Template
-from datetime import datetime #start_time = datetime.now()
 logger = logging.getLogger("TSScore")
-import time
 
 global settings
+
 
 class TSEvent(object, metaclass=ABCMeta):
     duration = None
@@ -30,60 +33,62 @@ class TSEvent(object, metaclass=ABCMeta):
     tie = None
 
     def render_colourful_output(self, text, pitchLetter, elementType):
-        figureNoteColours = {"C" : "red", "D" : "brown", "E" : "grey", "F" : "blue", "G" : "black", "A" : "yellow", "B" : "green"}
-        figureNoteContrastTextColours = {"C" : "white", "D" : "white", "E" : "white", "F" : "white", "G" : "white", "A" : "black", "B" : "white"}
+        figureNoteColours = {"C": "red", "D": "brown", "E": "grey", "F": "blue", "G": "black", "A": "yellow", "B": "green"}
+        figureNoteContrastTextColours = {"C": "white", "D": "white", "E": "white", "F": "white", "G": "white", "A": "black", "B": "white"}
         toRender = text
-        
-        if settings["colourPosition"]!="None":
+
+        if settings["colourPosition"] != "None":
             doColours = False
-            if (elementType=="pitch" and settings["colourPitch"]==True):
-                doColours=True  
-            if (elementType=="rhythm" and settings["colourRhythm"]==True):
-                doColours=True  
-            if (elementType=="octave" and settings["colourOctave"]==True):
-                doColours=True  
-                          
-            if doColours==True:
-                if settings["colourPosition"]=="background":
+            if (elementType == "pitch" and settings["colourPitch"] == True):
+                doColours = True
+            if (elementType == "rhythm" and settings["colourRhythm"] == True):
+                doColours = True
+            if (elementType == "octave" and settings["colourOctave"] == True):
+                doColours = True
+
+            if doColours == True:
+                if settings["colourPosition"] == "background":
                     toRender = "<span style='color:" + figureNoteContrastTextColours[pitchLetter] + "; background-color:" + figureNoteColours[pitchLetter] + ";'>" + text + "</span>"
-                elif settings["colourPosition"]=="text":
+                elif settings["colourPosition"] == "text":
                     toRender = "<span style='color:" + figureNoteColours[pitchLetter] + ";'>" + text + "</span>"
 
         return toRender
 
     def render(self, context=None, noteLetter=None):
         rendered_elements = []
-        if (context is None or context.duration != self.duration or self.tuplets!="" or settings['rhythmAnnouncement']=="everyNote"):
+        if (context is None or context.duration != self.duration or self.tuplets != "" or settings['rhythmAnnouncement'] == "everyNote"):
             rendered_elements.append(self.tuplets)
-            if (noteLetter!=None):
+            if (noteLetter != None):
                 rendered_elements.append(self.render_colourful_output(self.duration, noteLetter, "rhythm"))
             else:
                 rendered_elements.append(self.duration)
         rendered_elements.append(self.endTuplets)
-                
+
         if self.tie:
             rendered_elements.append("tie %s" % self.tie)
         return rendered_elements
+
 
 class TSDynamic(TSEvent):
     short_name = None
     long_name = None
 
     def __init__(self, long_name=None, short_name=None):
-        if (long_name!=None):
+        if (long_name != None):
             self.long_name = long_name.capitalize()
         else:
             self.long_name = short_name
-        
+
         self.short_name = short_name
 
     def render(self, context=None):
         return [self.long_name]
 
+
 class TSPitch(TSEvent):
     pitch_name = None
     octave = None
-    pitch_letter = None #used for looking up colour based on pitch and fixes sharp / flat problem when modulus and the pitch number
+    pitch_letter = None  # used for looking up colour based on pitch and fixes sharp / flat problem when modulus and the pitch number
 
     def __init__(self, pitch_name, octave, pitch_number, pitch_letter):
         self.pitch_name = pitch_name
@@ -94,46 +99,48 @@ class TSPitch(TSEvent):
     def render(self, context=None):
         global settings
         rendered_elements = []
-        if settings['octavePosition']=="before":
+        if settings['octavePosition'] == "before":
             rendered_elements.append(self.render_octave(context))
         rendered_elements.append(self.render_colourful_output(self.pitch_name, self.pitch_letter, "pitch"))
-        if settings['octavePosition']=="after":
+        if settings['octavePosition'] == "after":
             rendered_elements.append(self.render_octave(context))
-        
+
         return rendered_elements
 
     def render_octave(self, context=None):
         show_octave = False
-        if settings['octaveAnnouncement']=="brailleRules":
-            if context==None:
-                show_octave=True
+        if settings['octaveAnnouncement'] == "brailleRules":
+            if context == None:
+                show_octave = True
             else:
                 pitch_difference = abs(context.pitch_number - self.pitch_number)
-                #if it is a 3rd or less, don't say octave
-                if pitch_difference<=4:
-                    show_octave=False # it already is...
-                #if it is a 4th or 5th and octave changes, say octave
-                elif pitch_difference>=5 and pitch_difference<=7:
+                # if it is a 3rd or less, don't say octave
+                if pitch_difference <= 4:
+                    show_octave = False  # it already is...
+                # if it is a 4th or 5th and octave changes, say octave
+                elif pitch_difference >= 5 and pitch_difference <= 7:
                     if context.octave != self.octave:
-                        show_octave=True
-                #if it is more than a 5th, say octave
+                        show_octave = True
+                # if it is more than a 5th, say octave
                 else:
                     show_octave = True
-        elif settings['octaveAnnouncement']=="everyNote":
-            show_octave=True
-        elif settings['octaveAnnouncement']=="firstNote" and context==None:
-            show_octave=True
-        elif settings['octaveAnnouncement']=="onChange":
-            if context==None or (context!=None and context.octave != self.octave):
-                show_octave=True
-        
+        elif settings['octaveAnnouncement'] == "everyNote":
+            show_octave = True
+        elif settings['octaveAnnouncement'] == "firstNote" and context == None:
+            show_octave = True
+        elif settings['octaveAnnouncement'] == "onChange":
+            if context == None or (context != None and context.octave != self.octave):
+                show_octave = True
+
         if show_octave:
             return self.render_colourful_output(self.octave, self.pitch_letter, "octave")
         else:
             return ""
 
+
 class TSRest(TSEvent):
     pitch = None
+
     def render(self, context=None):
         rendered_elements = []
         # Render the duration
@@ -158,6 +165,7 @@ class TSNote(TSEvent):
         rendered_elements.append(' '.join(self.pitch.render(getattr(context, 'pitch', None))))
         return rendered_elements
 
+
 class TSChord(TSEvent):
     pitches = []
 
@@ -166,12 +174,13 @@ class TSChord(TSEvent):
 
     def render(self, context=None):
         rendered_elements = ['%s-note chord' % len(self.pitches)]
-        rendered_elements.append(' '.join(super(TSChord, self).render(context) ))
+        rendered_elements.append(' '.join(super(TSChord, self).render(context)))
         previous_pitch = None
         for pitch in sorted(self.pitches, key=lambda TSPitch: TSPitch.pitch_number):
-            rendered_elements.append(' '.join(pitch.render(previous_pitch) ))
+            rendered_elements.append(' '.join(pitch.render(previous_pitch)))
             previous_pitch = pitch
         return [', '.join(rendered_elements)]
+
 
 class TalkingScoreBase(object, metaclass=ABCMeta):
     @abstractmethod
@@ -181,6 +190,7 @@ class TalkingScoreBase(object, metaclass=ABCMeta):
     @abstractmethod
     def get_composer(self):
         pass
+
 
 class Music21TalkingScore(TalkingScoreBase):
 
@@ -205,10 +215,10 @@ class Music21TalkingScore(TalkingScoreBase):
     }
 
     _DOTS_MAP = {
-        0 : '',
-        1 : 'dotted ',
-        2 : 'double dotted ',
-        3 : 'triple dotted '
+        0: '',
+        1: 'dotted ',
+        2: 'double dotted ',
+        3: 'triple dotted '
     }
 
     _DURATION_MAP = {
@@ -242,8 +252,8 @@ class Music21TalkingScore(TalkingScoreBase):
         'B': 'bravo',
     }
 
-    last_tempo_inserted_index = 0 # insert_tempos() doesn't need to recheck MetronomeMarkBoundaries that have already been used
-    music_analyser = None;
+    last_tempo_inserted_index = 0  # insert_tempos() doesn't need to recheck MetronomeMarkBoundaries that have already been used
+    music_analyser = None
 
     def __init__(self, musicxml_filepath):
         self.filepath = os.path.realpath(musicxml_filepath)
@@ -259,7 +269,6 @@ class Music21TalkingScore(TalkingScoreBase):
                 return tb.content
         return "Unknown"
 
-
     def get_composer(self):
         if self.score.metadata.composer != None:
             return self.score.metadata.composer
@@ -271,17 +280,16 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def get_initial_time_signature(self):
         # Get the first measure of the first part
-        m1 = self.score.parts[0].measures(1,1)
+        m1 = self.score.parts[0].measures(1, 1)
         initial_time_signature = m1.getTimeSignatures()[0]
         return self.describe_time_signature(initial_time_signature)
-        
+
     def describe_time_signature(self, ts):
         return " ".join(ts.ratioString.split("/"))
-        
 
     def get_initial_key_signature(self):
-        m1 = self.score.parts[0].measures(1,1)
-        if len(m1.flat.getElementsByClass('KeySignature'))==0:
+        m1 = self.score.parts[0].measures(1, 1)
+        if len(m1.flat.getElementsByClass('KeySignature')) == 0:
             ks = key.KeySignature(0)
         else:
             ks = m1.flat.getElementsByClass('KeySignature')[0]
@@ -289,16 +297,16 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def describe_key_signature(self, ks):
         strKeySig = "No sharps or flats"
-        if (ks.sharps>0):
+        if (ks.sharps > 0):
             strKeySig = str(ks.sharps) + " sharps"
-        elif (ks.sharps<0):
+        elif (ks.sharps < 0):
             strKeySig = str(abs(ks.sharps)) + " flats"
         return strKeySig
 
     # this was used to get the first tempo - but MetronomeMarkBoundary is better
     def get_initial_text_expression(self):
         # Get the first measure of the first part
-        m1 = self.score.parts[0].measures(1,1)
+        m1 = self.score.parts[0].measures(1, 1)
         # Get the text expressions from that measure
         text_expressions = m1.flat.getElementsByClass('TextExpression')
         for te in text_expressions:
@@ -306,34 +314,36 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def get_initial_tempo(self):
         global settings
-        try: settings
-        except NameError: settings = None
+        try:
+            settings
+        except NameError:
+            settings = None
         if settings == None:
-            settings={}
-            settings['dotPosition']="before"
-            settings['rhythmDescription']="british"
+            settings = {}
+            settings['dotPosition'] = "before"
+            settings['rhythmDescription'] = "british"
         return self.describe_tempo(self.score.metronomeMarkBoundaries()[0][2])
 
     def describe_tempo(self, tempo):
         tempo_text = ""
-        if (tempo.text!=None):
-            tempo_text += tempo.text + " (" + str(math.floor(tempo.number))  + " bpm @ " + self.describe_tempo_referent(tempo) + ")"
+        if (tempo.text != None):
+            tempo_text += tempo.text + " (" + str(math.floor(tempo.number)) + " bpm @ " + self.describe_tempo_referent(tempo) + ")"
         else:
-            tempo_text += str(math.floor(tempo.number))  + " bpm @ " + self.describe_tempo_referent(tempo)
+            tempo_text += str(math.floor(tempo.number)) + " bpm @ " + self.describe_tempo_referent(tempo)
         print(text)
         return tempo_text
 
     # the referent is the beat duration ie are you counting crotchets or minims etc
     def describe_tempo_referent(self, tempo):
         global settings
-        tempo_text=""
-        if settings['dotPosition']=="before":
+        tempo_text = ""
+        if settings['dotPosition'] == "before":
             tempo_text = self._DOTS_MAP.get(tempo.referent.dots)
         tempo_text += self.map_duration(tempo.referent)
-        if settings['dotPosition']=="after":
+        if settings['dotPosition'] == "after":
             tempo_text += " " + self._DOTS_MAP.get(tempo.referent.dots)
-        
-        return tempo_text   
+
+        return tempo_text
 
     def get_number_of_bars(self):
         return len(self.score.parts[0].getElementsByClass('Measure'))
@@ -343,84 +353,84 @@ class Music21TalkingScore(TalkingScoreBase):
     # part_names = {1: 'Right hand', 2: 'Left hand', 4: 'Right hand', 5: 'Left hand'}
     # instrument names = ['Flute', 'Piano', 'Recorder', 'Piano']
     def get_instruments(self):
-        #eg instrument.Name = Piano, instrument.partId = 1.  A piano has 2 staves ie two parts with the same name and same ID.  But if you have a second piano, it will have the same name but a different partId
-        self.part_instruments={} # key = instrument (1 based), value = ["part name", 1st part index 0 based, number of parts, instrument.partId] 
-        self.part_names = {} # key = part index 0 based, {part name eg "left hand" or "right hand" etc} - but part only included if instrument has multiple parts.
-        instrument_names=[] # each instrument instrument once even if it has multiple parts.  still needed for Info / Options page
+        # eg instrument.Name = Piano, instrument.partId = 1.  A piano has 2 staves ie two parts with the same name and same ID.  But if you have a second piano, it will have the same name but a different partId
+        self.part_instruments = {}  # key = instrument (1 based), value = ["part name", 1st part index 0 based, number of parts, instrument.partId]
+        self.part_names = {}  # key = part index 0 based, {part name eg "left hand" or "right hand" etc} - but part only included if instrument has multiple parts.
+        instrument_names = []  # each instrument instrument once even if it has multiple parts.  still needed for Info / Options page
         ins_count = 1
         for c, instrument in enumerate(self.score.flat.getInstruments()):
             if len(self.part_instruments) == 0 or self.part_instruments[ins_count-1][3] != instrument.partId:
                 pname = instrument.partName
-                if pname==None:
+                if pname == None:
                     pname = "Instrument  " + str(ins_count) + " (unnamed)"
                 self.part_instruments[ins_count] = [pname, c, 1, instrument.partId]
                 instrument_names.append(pname)
-                
-                ins_count+=1
+
+                ins_count += 1
             else:
-                self.part_instruments[ins_count-1][2]+=1
-                #todo - there is a more efficient way of doing this - or just let the user enter part names on the options screen - but these are OK for defaults
+                self.part_instruments[ins_count-1][2] += 1
+                # todo - there is a more efficient way of doing this - or just let the user enter part names on the options screen - but these are OK for defaults
                 if self.part_instruments[ins_count-1][2] == 2:
-                   self.part_names[c-1] = "Right hand"
-                   self.part_names[c] = "Left hand"
+                    self.part_names[c-1] = "Right hand"
+                    self.part_names[c] = "Left hand"
                 elif self.part_instruments[ins_count-1][2] == 3:
-                   self.part_names[c-2] = "Part 1"
-                   self.part_names[c-1] = "Part 2"
-                   self.part_names[c] = "Part 3"
+                    self.part_names[c-2] = "Part 1"
+                    self.part_names[c-1] = "Part 2"
+                    self.part_names[c] = "Part 3"
                 else:
                     self.part_names[c] = "Part " + str(self.part_instruments[ins_count-1][2])
 
         logger.debug(f"part instruments = {self.part_instruments}")
         print("part names = " + str(self.part_names))
         print("instrument names = " + str(instrument_names))
-        return instrument_names 
+        return instrument_names
 
     def compare_parts_with_selected_instruments(self):
         global settings
-        self.selected_instruments = [] #1 based list of keys from part_instruments eg [1, 4]
-        self.unselected_instruments = [] # eg [2,3]
-        self.binary_selected_instruments = 1 #bitwise representation of all instruments - 0=not included, 1=included
-        self.selected_part_names=[] # eg ["recorder", "piano - left hand", "piano - right hand"]
+        self.selected_instruments = []  # 1 based list of keys from part_instruments eg [1, 4]
+        self.unselected_instruments = []  # eg [2,3]
+        self.binary_selected_instruments = 1  # bitwise representation of all instruments - 0=not included, 1=included
+        self.selected_part_names = []  # eg ["recorder", "piano - left hand", "piano - right hand"]
         for ins in self.part_instruments.keys():
-            self.binary_selected_instruments =  self.binary_selected_instruments<<1
+            self.binary_selected_instruments = self.binary_selected_instruments << 1
             if ins in settings['instruments']:
                 self.selected_instruments.append(ins)
-                self.binary_selected_instruments+=1
+                self.binary_selected_instruments += 1
             else:
                 self.unselected_instruments.append(ins)
-        
+
         for ins in self.selected_instruments:
             ins_name = self.part_instruments[ins][0]
-            if self.part_instruments[ins][2]==1: #instrument only has one part
+            if self.part_instruments[ins][2] == 1:  # instrument only has one part
                 self.selected_part_names.append(ins_name)
-            else: # instrument has multiple parts
+            else:  # instrument has multiple parts
                 pn1index = self.part_instruments[ins][1]
                 for pni in range(pn1index, pn1index+self.part_instruments[ins][2]):
                     self.selected_part_names.append(ins_name + " - " + self.part_names[pni])
-                    
-        print ("selected_part_names = " + str(self.selected_part_names))
 
-        if len(self.unselected_instruments)==0: #All instruments selected - so no unselected instruments to play
+        print("selected_part_names = " + str(self.selected_part_names))
+
+        if len(self.unselected_instruments) == 0:  # All instruments selected - so no unselected instruments to play
             settings['playUnselected'] = False
-        if len(self.selected_instruments)==len(self.part_instruments) and settings['playAll']==True: #played by Play All
+        if len(self.selected_instruments) == len(self.part_instruments) and settings['playAll'] == True:  # played by Play All
             settings['playSelected'] = False
-        if len(self.selected_instruments)==1: #played by individual part
+        if len(self.selected_instruments) == 1:  # played by individual part
             settings['playSelected'] = False
-        if len(self.part_instruments)==1:
+        if len(self.part_instruments) == 1:
             settings['playAll'] = False
 
-        #todo - these maybe shouldn't really be part of score...
-        self.binary_play_all = 1 # placeholder,all,selected,unslected
+        # todo - these maybe shouldn't really be part of score...
+        self.binary_play_all = 1  # placeholder,all,selected,unslected
         self.binary_play_all = self.binary_play_all << 1
         if settings['playAll'] == True:
-            self.binary_play_all +=1
+            self.binary_play_all += 1
         self.binary_play_all = self.binary_play_all << 1
         if settings['playSelected'] == True:
-            self.binary_play_all +=1
+            self.binary_play_all += 1
         self.binary_play_all = self.binary_play_all << 1
         if settings['playUnselected'] == True:
-            self.binary_play_all +=1
-        
+            self.binary_play_all += 1
+
         print("selected_instruments = " + str(self.selected_instruments))
 
     def get_number_of_parts(self):
@@ -437,36 +447,36 @@ class Music21TalkingScore(TalkingScoreBase):
 
     def get_events_for_bar_range(self, start_bar, end_bar, part_index):
         events_by_bar = {}
-        
+
         # using collect=('TimeSignature') is slow.  It is almost twice as fast to use a dictionary of time signatures and insert at the start of each segment.
         measures = self.score.parts[part_index].measures(start_bar, end_bar)
-        if measures.measure(start_bar)!=None and len(measures.measure(start_bar).getElementsByClass(meter.TimeSignature))==0:
+        if measures.measure(start_bar) != None and len(measures.measure(start_bar).getElementsByClass(meter.TimeSignature)) == 0:
             measures.measure(start_bar).insert(0, self.timeSigs[start_bar])
 
         logger.info(f'Processing part - {part_index} - bars {start_bar} to {end_bar}')
         # Iterate over the bars one at a time
         # pickup bar has to request measures 0 to 1 above otherwise it returns an measures just has empty parts - so now restrict it just to bar 0...
-        if start_bar==0 and end_bar==1:
-            end_bar=0
+        if start_bar == 0 and end_bar == 1:
+            end_bar = 0
         for bar_index in range(start_bar, end_bar + 1):
             measure = measures.measure(bar_index)
             if measure is not None:
                 self.update_events_for_measure(measure, events_by_bar)
 
         # Iterate over the spanners
-        #todo - mention slurs?  Make it an option?  
-        #todo - this looks at spanners per part so eg crescendos are described for the right hand but not the left of a piano...
-        #todo - it is a bit inefficient.  It looks spanners from the start of the part for each segment...
+        # todo - mention slurs?  Make it an option?
+        # todo - this looks at spanners per part so eg crescendos are described for the right hand but not the left of a piano...
+        # todo - it is a bit inefficient.  It looks spanners from the start of the part for each segment...
         for spanner in self.score.parts[part_index].spanners.elements:
             first = spanner.getFirst()
-            last  = spanner.getLast()
+            last = spanner.getLast()
             if first.measureNumber is None or last.measureNumber is None:
                 continue
-            elif first.measureNumber > end_bar: # all remaining spanners are after this segment so break the for loop
+            elif first.measureNumber > end_bar:  # all remaining spanners are after this segment so break the for loop
                 break
 
             spanner_type = type(spanner).__name__
-            if spanner_type == 'Crescendo' or spanner_type == 'Diminuendo': 
+            if spanner_type == 'Crescendo' or spanner_type == 'Diminuendo':
                 description_order = 0
                 voice = 1
 
@@ -481,45 +491,43 @@ class Music21TalkingScore(TalkingScoreBase):
 
                 if last.measureNumber >= start_bar and last.measureNumber <= end_bar:
                     event = TSDynamic(long_name='%s end' % spanner_type)
-                    #todo -  Note - THIS WILL NOT HANDLE CRESCENDOS/DIMINUENDOS THAT SPAN MEASURES
+                    # todo -  Note - THIS WILL NOT HANDLE CRESCENDOS/DIMINUENDOS THAT SPAN MEASURES
                     events_by_bar\
                         .setdefault(last.measureNumber, {})\
                         .setdefault(last.beat + last.duration.quarterLength - 1, {})\
                         .setdefault(voice, {})\
                         .setdefault(description_order, [])\
                         .append(event)
-        
 
         return events_by_bar
 
-    def update_events_for_measure(self, measure, events, voice:int=1):
+    def update_events_for_measure(self, measure, events, voice: int = 1):
         previous_beat = 1
         for element in measure.elements:
             element_type = type(element).__name__
             event = None
             if element_type == 'Note':
                 event = TSNote()
-                event.pitch = TSPitch( self.map_pitch(element.pitch), self.map_octave(element.pitch.octave), element.pitch.ps, element.pitch.name[0] )
+                event.pitch = TSPitch(self.map_pitch(element.pitch), self.map_octave(element.pitch.octave), element.pitch.ps, element.pitch.name[0])
                 description_order = 1
                 if element.tie:
                     event.tie = element.tie.type
- 
+
                 event.expressions = element.expressions
             elif element_type == 'Rest':
                 event = TSRest()
                 description_order = 1
-                
+
             elif element_type == 'Chord':
                 event = TSChord()
-                event.pitches = [ TSPitch(self.map_pitch(element_pitch), self.map_octave(element_pitch.octave), element_pitch.ps, element_pitch.name[0]) for element_pitch in element.pitches ]
+                event.pitches = [TSPitch(self.map_pitch(element_pitch), self.map_octave(element_pitch.octave), element_pitch.ps, element_pitch.name[0]) for element_pitch in element.pitches]
                 description_order = 1
                 if element.tie:
                     event.tie = element.tie.type
 
             elif element_type == 'Dynamic':
-                event = TSDynamic(long_name = element.longName, short_name=element.value)
-                description_order = 0 # Always speak the dynamic first
-                
+                event = TSDynamic(long_name=element.longName, short_name=element.value)
+                description_order = 0  # Always speak the dynamic first
 
             elif element_type == 'Voice':
                 self.update_events_for_measure(element, events, int(element.id))
@@ -530,26 +538,26 @@ class Music21TalkingScore(TalkingScoreBase):
             # This test isn't WORKING
             # if TSEvent.__class__ in event.__class__.__bases__:
             event.duration = ""
-            if (len(element.duration.tuplets)>0):
-                if (element.duration.tuplets[0].type=="start"):
-                    if (element.duration.tuplets[0].fullName=="Triplet"):
+            if (len(element.duration.tuplets) > 0):
+                if (element.duration.tuplets[0].type == "start"):
+                    if (element.duration.tuplets[0].fullName == "Triplet"):
                         event.tuplets = "triplets "
                     else:
                         event.tuplets = element.duration.tuplets[0].fullName + " (" + str(element.duration.tuplets[0].tupletActual[0]) + " in " + str(element.duration.tuplets[0].tupletNormal[0]) + ") "
-                elif (element.duration.tuplets[0].type=="stop" and element.duration.tuplets[0].fullName!="Triplet"):
-                    event.endTuplets = "end tuplet " 
+                elif (element.duration.tuplets[0].type == "stop" and element.duration.tuplets[0].fullName != "Triplet"):
+                    event.endTuplets = "end tuplet "
 
-            if settings['dotPosition']=="before":
+            if settings['dotPosition'] == "before":
                 event.duration += self.map_dots(element.duration.dots)
             event.duration += self.map_duration(element.duration)
-            if settings['dotPosition']=="after":
+            if settings['dotPosition'] == "after":
                 event.duration += " " + self.map_dots(element.duration.dots)
-            
-            if (math.floor(element.beat)==math.floor(previous_beat)): # eg was 1 now 1.5 ie same beat
+
+            if (math.floor(element.beat) == math.floor(previous_beat)):  # eg was 1 now 1.5 ie same beat
                 beat = previous_beat
-            elif (math.floor(element.beat)==element.beat): # was 1.5 now 2.0 - ie start of a new beat
-                beat = math.floor(element.beat) # strip off the point 0
-            else: # eg was 1 now 2.5 ie part way through a new beat - mention decimal
+            elif (math.floor(element.beat) == element.beat):  # was 1.5 now 2.0 - ie start of a new beat
+                beat = math.floor(element.beat)  # strip off the point 0
+            else:  # eg was 1 now 2.5 ie part way through a new beat - mention decimal
                 beat = element.beat
             previous_beat = beat
 
@@ -560,263 +568,260 @@ class Music21TalkingScore(TalkingScoreBase):
                 .setdefault(description_order, [])\
                 .append(event)
 
-
     def group_chord_pitches_by_octave(self, chord):
         chord_pitches_by_octave = {}
         for pitch in chord.pitches:
-            chord_pitches_by_octave.setdefault(self._PITCH_MAP.get(str(pitch.octave),'?'), []).append(pitch.name)
+            chord_pitches_by_octave.setdefault(self._PITCH_MAP.get(str(pitch.octave), '?'), []).append(pitch.name)
 
         return chord_pitches_by_octave
 
-    
-    #for all / selected / unselected
+    # for all / selected / unselected
+
     def generate_midi_filename_sel(self, prefix, range_start=None, range_end=None, output_path="", sel=""):
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-        if (range_start!=None):
-            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&start=%d&end=%d&t=100&c=n" % ( base_filename, sel, range_start,range_end )) )
+        if (range_start != None):
+            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&start=%d&end=%d&t=100&c=n" % (base_filename, sel, range_start, range_end)))
         else:
-            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&t=100&c=n" % ( base_filename, sel,  )) )
+            midi_filename = os.path.join(output_path, ("%s.mid?sel=%s&t=100&c=n" % (base_filename, sel,)))
         return (prefix+os.path.basename(midi_filename))
 
     def generate_part_descriptions(self, instrument, start_bar, end_bar):
         part_descriptions = []
-        for pi in range (self.part_instruments[instrument][1], self.part_instruments[instrument][1]+self.part_instruments[instrument][2]):
+        for pi in range(self.part_instruments[instrument][1], self.part_instruments[instrument][1]+self.part_instruments[instrument][2]):
             part_descriptions.append(self.get_events_for_bar_range(start_bar, end_bar, pi))
-            
+
         return part_descriptions
 
     def generate_midi_filenames(self, prefix, range_start=None, range_end=None, add_instruments=[], output_path="", postfix_filename=""):
         part_midis = []
         if range_start is None and range_end is None:
             for ins in add_instruments:
-                for pi in range (self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
-                    if self.part_instruments[ins][2]>1:
+                for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
+                    if self.part_instruments[ins][2] > 1:
                         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&t=100&c=n" % ( base_filename, pi ) )
+                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&t=100&c=n" % (base_filename, pi))
                         part_midis.append(midi_filename)
-        else: #specific measures
+        else:  # specific measures
             for ins in add_instruments:
-                for pi in range (self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
-                    if self.part_instruments[ins][2]>1:
+                for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
+                    if self.part_instruments[ins][2] > 1:
                         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&start=%d&end=%d&t=100&c=n" % ( base_filename, pi, range_start, range_end ) )
+                        midi_filename = os.path.join(output_path, "%s.mid?part=%d&start=%d&end=%d&t=100&c=n" % (base_filename, pi, range_start, range_end))
                         part_midis.append(midi_filename)
 
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-        if (range_start!=None):
-            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&start=%d&end=%d&t=100&c=n" % ( base_filename,ins, range_start,range_end )) )
+        if (range_start != None):
+            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&start=%d&end=%d&t=100&c=n" % (base_filename, ins, range_start, range_end)))
         else:
-            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&t=100&c=n" % ( base_filename,ins,  )) )
+            midi_filename = os.path.join(output_path, ("%s.mid?ins=%d&t=100&c=n" % (base_filename, ins,)))
         part_midis = [prefix + os.path.basename(s) for s in part_midis]
         return (prefix+os.path.basename(midi_filename), part_midis)
 
-    
     def generate_midi_for_instruments(self, prefix, range_start=None, range_end=None, add_instruments=[], output_path="", postfix_filename=""):
         part_midis = []
         s = stream.Score(id='temp')
-        
+
         if range_start is None and range_end is None:
             for ins in add_instruments:
-                for pi in range (self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
+                for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
                     s.insert(self.score.parts[pi])
-                    if self.part_instruments[ins][2]>1:
+                    if self.part_instruments[ins][2] > 1:
                         part_midis.append(self.generate_midi_parts_for_instrument(range_start, range_end, ins, pi-self.part_instruments[ins][1], output_path, postfix_filename))
 
-        else: #specific measures
+        else:  # specific measures
             postfix_filename += "_" + str(range_start) + str(range_end)
             for ins in add_instruments:
                 firstPart = True
-                for pi in range (self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
-                    if self.part_instruments[ins][2]>1:
+                for pi in range(self.part_instruments[ins][1], self.part_instruments[ins][1]+self.part_instruments[ins][2]):
+                    if self.part_instruments[ins][2] > 1:
                         part_midis.append(self.generate_midi_parts_for_instrument(range_start, range_end, ins, pi-self.part_instruments[ins][1], output_path, postfix_filename))
                     pi_measures = self.score.parts[pi].measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
                     if firstPart:
-                        if pi!=0: # only part 0 has tempos
+                        if pi != 0:  # only part 0 has tempos
                             self.insert_tempos(pi_measures, self.score.parts[0].measure(range_start).offset)
-                        firstPart=False
-                    
-                    #music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
+                        firstPart = False
+
+                    # music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
                     for m in pi_measures.getElementsByClass('Measure'):
-                        m.removeByClass('Repeat') 
-                    s.insert(pi_measures)            
+                        m.removeByClass('Repeat')
+                    s.insert(pi_measures)
 
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-        midi_filename = os.path.join(output_path, "%s%s.mid" % ( base_filename, postfix_filename ) )
-        #todo - might need to add in tempos if part 0 is not included
+        midi_filename = os.path.join(output_path, "%s%s.mid" % (base_filename, postfix_filename))
+        # todo - might need to add in tempos if part 0 is not included
         if not os.path.exists(midi_filename):
             s.write('midi', midi_filename)
         part_midis = [prefix + os.path.basename(s) for s in part_midis]
         return (prefix+os.path.basename(midi_filename), part_midis)
 
     def generate_midi_parts_for_instrument(self, range_start=None, range_end=None, instrument=0, part=0, output_path="", postfix_filename=""):
-        s = stream.Score(id='temp')   
+        s = stream.Score(id='temp')
         if range_start is None and range_end is None:
             s = stream.Score(id='temp')
             s.insert(self.score.parts[self.part_instruments[instrument][1]+part])
             base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % ( base_filename, postfix_filename, str(part+1) ) )
+            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % (base_filename, postfix_filename, str(part+1)))
             if not os.path.exists(midi_filename):
                 s.write('midi', midi_filename)
-        else: #specific measures
+        else:  # specific measures
             postfix_filename += "_" + str(range_start) + str(range_end)
             s = stream.Score(id='temp')
             print("506 instrument = " + str(instrument) + " part = " + str(part))
             pi_measures = self.score.parts[self.part_instruments[instrument][1]+part].measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
-            if self.part_instruments[instrument][1]+part!=0: # only part 0 has tempos
+            if self.part_instruments[instrument][1]+part != 0:  # only part 0 has tempos
                 self.insert_tempos(pi_measures, self.score.parts[0].measure(range_start).offset)
-            
-            #music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
+
+            # music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
             for m in pi_measures.getElementsByClass('Measure'):
-                m.removeByClass('Repeat') 
-            s.insert(pi_measures)            
+                m.removeByClass('Repeat')
+            s.insert(pi_measures)
 
             base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
-            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % ( base_filename, postfix_filename, str(part+1) ) )
+            midi_filename = os.path.join(output_path, "%s%s_p%s.mid" % (base_filename, postfix_filename, str(part+1)))
             if not os.path.exists(midi_filename):
                 s.write('midi', midi_filename)
         return midi_filename
 
     def generate_midi_for_part_range(self, range_start=None, range_end=None, parts=[], output_path=""):
-        
+
         base_filename = os.path.splitext(os.path.basename(self.filepath))[0]
         if range_start is None and range_end is None:
             # Export the whole score
-            midi_filename = os.path.join(output_path, "%s.mid" % ( base_filename ) )
+            midi_filename = os.path.join(output_path, "%s.mid" % (base_filename))
             if not os.path.exists(midi_filename):
                 self.score.write('midi', midi_filename)
             return midi_filename
-        elif len(parts) > 0: #individual parts
+        elif len(parts) > 0:  # individual parts
             for p in self.score.parts:
                 if p.id not in parts:
                     continue
 
-                midi_filename = os.path.join(output_path, "%s_p%s_%s_%s.mid" % ( base_filename, p.id, range_start, range_end ) )
+                midi_filename = os.path.join(output_path, "%s_p%s_%s_%s.mid" % (base_filename, p.id, range_start, range_end))
                 if not os.path.exists(midi_filename):
                     midi_stream = p.measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
-                    if p!=self.score.parts[0]: # only part 0 has tempos
+                    if p != self.score.parts[0]:  # only part 0 has tempos
                         self.insert_tempos(midi_stream, self.score.parts[0].measure(range_start).offset)
-                    #music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
+                    # music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
                     for m in midi_stream.getElementsByClass('Measure'):
-                        m.removeByClass('Repeat')   
+                        m.removeByClass('Repeat')
                     midi_stream.write('midi', midi_filename)
                 return midi_filename
-        else: # both hands
-            midi_filename = os.path.join(output_path, "%s_%s_%s.mid" % ( base_filename, range_start, range_end ))
+        else:  # both hands
+            midi_filename = os.path.join(output_path, "%s_%s_%s.mid" % (base_filename, range_start, range_end))
             if not os.path.exists(midi_filename):
                 midi_stream = self.score.measures(range_start, range_end, collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'TempoIndication'))
-                #music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
+                # music21 v6.3.0 tries to expand repeats - which causes error if segment only includes the start repeat mark
                 for pa in midi_stream.getElementsByClass('Part'):
                     for m in pa.getElementsByClass('Measure'):
-                        m.removeByClass('Repeat') 
+                        m.removeByClass('Repeat')
                 midi_stream.write('midi', midi_filename)
             return midi_filename
 
         return None
-       
-    #TODO need to make more efficient when working with multiple parts ie more than just the left hand piano part
-    #music21 might have a better way of doing this.  If part 0 is included then tempos are already present.
-    def insert_tempos(self, stream, offset_start):       
-        if (self.last_tempo_inserted_index>0): # one tempo change might need to be in many segments - especially the last tempo change in the score
-            self.last_tempo_inserted_index-=1
+
+    # TODO need to make more efficient when working with multiple parts ie more than just the left hand piano part
+    # music21 might have a better way of doing this.  If part 0 is included then tempos are already present.
+    def insert_tempos(self, stream, offset_start):
+        if (self.last_tempo_inserted_index > 0):  # one tempo change might need to be in many segments - especially the last tempo change in the score
+            self.last_tempo_inserted_index -= 1
         for mmb in self.score.metronomeMarkBoundaries()[self.last_tempo_inserted_index:]:
-            if (mmb[0]>=offset_start+stream.duration.quarterLength): # ignore tempos that start after stream ends
-                return           
-            if (mmb[1]>offset_start): # if mmb ends during the segment
-                if (mmb[0])<=offset_start: # starts before segment so insert it at the start of the stream
+            if (mmb[0] >= offset_start+stream.duration.quarterLength):  # ignore tempos that start after stream ends
+                return
+            if (mmb[1] > offset_start):  # if mmb ends during the segment
+                if (mmb[0]) <= offset_start:  # starts before segment so insert it at the start of the stream
                     stream.insert(0, tempo.MetronomeMark(number=mmb[2].number))
-                    self.last_tempo_inserted_index+=1
-                else: # starts during segment so insert it part way through the stream
+                    self.last_tempo_inserted_index += 1
+                else:  # starts during segment so insert it part way through the stream
                     stream.insert(mmb[0]-offset_start, tempo.MetronomeMark(number=mmb[2].number))
-                    self.last_tempo_inserted_index+=1
-       
+                    self.last_tempo_inserted_index += 1
+
     def map_octave(self, octave):
         global settings
-        if settings['octaveDescription']=="figureNotes":
+        if settings['octaveDescription'] == "figureNotes":
             return self._OCTAVE_FIGURENOTES_MAP.get(octave, "?")
-        elif settings['octaveDescription']=="name":
+        elif settings['octaveDescription'] == "name":
             return self._OCTAVE_MAP.get(octave, "?")
-        elif settings['octaveDescription']=="none":
+        elif settings['octaveDescription'] == "none":
             return ""
-        elif settings['octaveDescription']=="number":
+        elif settings['octaveDescription'] == "number":
             return str(octave)
-        
+
         # return "%s %s" % (self._PITCH_MAP.get(pitch[-1], ''), pitch[0] )
 
     def map_pitch(self, pitch):
         global settings
-        if settings['pitchDescription']=="colourNotes":
+        if settings['pitchDescription'] == "colourNotes":
             pitch_name = self._PITCH_FIGURENOTES_MAP.get(pitch.name[0], "?")
-        if settings['pitchDescription']=="noteName":
+        if settings['pitchDescription'] == "noteName":
             pitch_name = pitch.name[0]
-        elif settings['pitchDescription']=="none":
+        elif settings['pitchDescription'] == "none":
             pitch_name = ""
-        elif settings['pitchDescription']=="phonetic":
+        elif settings['pitchDescription'] == "phonetic":
             pitch_name = self._PITCH_PHONETIC_MAP.get(pitch.name[0], "?")
-        
-        if pitch.accidental and pitch.accidental.displayStatus and pitch_name!="":
+
+        if pitch.accidental and pitch.accidental.displayStatus and pitch_name != "":
             pitch_name = "%s %s" % (pitch_name, pitch.accidental.fullName)
         return pitch_name
 
     def map_duration(self, duration):
         global settings
-        if settings['rhythmDescription']=="american":
+        if settings['rhythmDescription'] == "american":
             return duration.type
-        elif settings['rhythmDescription']=="british":
-            return self._DURATION_MAP.get(duration.type, 'Unknown duration %s'%duration.type)
-        elif settings['rhythmDescription']=="none":
+        elif settings['rhythmDescription'] == "british":
+            return self._DURATION_MAP.get(duration.type, 'Unknown duration %s' % duration.type)
+        elif settings['rhythmDescription'] == "none":
             return ""
-        
 
     def map_dots(self, dots):
-        if settings['rhythmDescription']=="none":
+        if settings['rhythmDescription'] == "none":
             return ""
         else:
             return self._DOTS_MAP.get(dots)
+
 
 class HTMLTalkingScoreFormatter():
 
     def __init__(self, talking_score):
         global settings
-        
-        self.score:Music21TalkingScore = talking_score
+
+        self.score: Music21TalkingScore = talking_score
 
         options_path = self.score.filepath + '.opts'
         with open(options_path, "r") as options_fh:
-                options = json.load(options_fh)
+            options = json.load(options_fh)
         settings = {
             'pitchBeforeDuration': False,
             'describeBy': 'beat',
             'handsTogether': True,
             'barsAtATime': int(options["bars_at_a_time"]),
-            'playAll':options["play_all"],
-            'playSelected':options["play_selected"],
-            'playUnselected':options["play_unselected"],
-            'instruments':options["instruments"],
-            'pitchDescription':options["pitch_description"],
-            'rhythmDescription':options["rhythm_description"],
-            'dotPosition':options["dot_position"],
-            'rhythmAnnouncement':options["rhythm_announcement"],
-            'octaveDescription':options["octave_description"],
-            'octavePosition':options["octave_position"],
-            'octaveAnnouncement':options["octave_announcement"],
-            'colourPosition':options["colour_position"],
-            'colourPitch':options["colour_pitch"],
-            'colourRhythm':options["colour_rhythm"],
-            'colourOctave':options["colour_octave"],
+            'playAll': options["play_all"],
+            'playSelected': options["play_selected"],
+            'playUnselected': options["play_unselected"],
+            'instruments': options["instruments"],
+            'pitchDescription': options["pitch_description"],
+            'rhythmDescription': options["rhythm_description"],
+            'dotPosition': options["dot_position"],
+            'rhythmAnnouncement': options["rhythm_announcement"],
+            'octaveDescription': options["octave_description"],
+            'octavePosition': options["octave_position"],
+            'octaveAnnouncement': options["octave_announcement"],
+            'colourPosition': options["colour_position"],
+            'colourPitch': options["colour_pitch"],
+            'colourRhythm': options["colour_rhythm"],
+            'colourOctave': options["colour_octave"],
         }
-        
 
-    def generateHTML(self,output_path="",web_path=""):
+    def generateHTML(self, output_path="", web_path=""):
         global settings
         from jinja2 import Environment, FileSystemLoader
         env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)))
         template = env.get_template('talkingscore.html')
-        
+
         self.score.get_instruments()
         self.score.compare_parts_with_selected_instruments()
-        print ("Settings...")
-        print (settings)
-        
+        print("Settings...")
+        print(settings)
+
         self.music_analyser = MusicAnalyser()
         self.music_analyser.setScore(self.score)
         start = self.score.score.parts[0].getElementsByClass('Measure')[0].number
@@ -824,30 +829,30 @@ class HTMLTalkingScoreFormatter():
         selected_instruments_midis = {}
         for index, ins in enumerate(self.score.selected_instruments):
             midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=start, range_end=end, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
-            selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
-        
+            selected_instruments_midis[ins] = {"ins": ins,  "midi": midis[0], "midi_parts": midis[1]}
+
         midiAll = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="all")
         midiSelected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="sel")
         midiUnselected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=start, range_end=end, sel="un")
-        full_score_midis = {'selected_instruments_midis':selected_instruments_midis, 'midi_all':midiAll, 'midi_sel':midiSelected, 'midi_un':midiUnselected }
-        
-        return template.render({'settings' : settings,
+        full_score_midis = {'selected_instruments_midis': selected_instruments_midis, 'midi_all': midiAll, 'midi_sel': midiSelected, 'midi_un': midiUnselected}
+
+        return template.render({'settings': settings,
                                 'basic_information': self.get_basic_information(),
                                 'preamble': self.get_preamble(),
                                 'full_score_midis': full_score_midis,
-                                'music_segments': self.get_music_segments(output_path,web_path, ),
-                                'instruments' : self.score.part_instruments,
-                                'part_names' : self.score.part_names,
-                                'binary_selected_instruments' : self.score.binary_selected_instruments,
-                                'binary_play_all' : self.score.binary_play_all,
-                                'play_all' : settings['playAll'],
-                                'play_selected' : settings['playSelected'],
-                                'play_unselected' : settings['playUnselected'],
-                                'time_and_keys' : self.time_and_keys,
-                                'parts_summary' : self.music_analyser.summary_parts,
-                                'general_summary' : self.music_analyser.general_summary,
-                                'repetition_in_contexts' : self.music_analyser.repetition_in_contexts,
-                                'selected_part_names' : self.score.selected_part_names,
+                                'music_segments': self.get_music_segments(output_path, web_path, ),
+                                'instruments': self.score.part_instruments,
+                                'part_names': self.score.part_names,
+                                'binary_selected_instruments': self.score.binary_selected_instruments,
+                                'binary_play_all': self.score.binary_play_all,
+                                'play_all': settings['playAll'],
+                                'play_selected': settings['playSelected'],
+                                'play_unselected': settings['playUnselected'],
+                                'time_and_keys': self.time_and_keys,
+                                'parts_summary': self.music_analyser.summary_parts,
+                                'general_summary': self.music_analyser.general_summary,
+                                'repetition_in_contexts': self.music_analyser.repetition_in_contexts,
+                                'selected_part_names': self.score.selected_part_names,
                                 })
 
     def get_basic_information(self):
@@ -865,21 +870,19 @@ class HTMLTalkingScoreFormatter():
             'number_of_parts': self.score.get_number_of_parts(),
         }
 
-    
-
-    def get_music_segments(self,output_path,web_path):
-        print ("web path = ")
+    def get_music_segments(self, output_path, web_path):
+        print("web path = ")
         print(web_path)
         print("base name webpath = ")
-        print(os.path.basename(web_path)) 
+        print(os.path.basename(web_path))
 
         global settings
         logger.info("Start of get_music_segments")
         music_segments = []
         number_of_bars = self.score.get_number_of_bars()
-        
+
         t1s = time.time()
-        self.time_and_keys = {} # index is bar number, key = "Time sig x of y - 4 4..."
+        self.time_and_keys = {}  # index is bar number, key = "Time sig x of y - 4 4..."
         total = len(self.score.score.parts[0].flat.getElementsByClass('TimeSignature'))
         for count, ts in enumerate(self.score.score.parts[0].flat.getElementsByClass('TimeSignature')):
             description = "Time signature - " + str(count+1) + " of " + str(total) + " is " + self.score.describe_time_signature(ts) + ".  "
@@ -889,69 +892,69 @@ class HTMLTalkingScoreFormatter():
         for count, ks in enumerate(self.score.score.parts[0].flat.getElementsByClass('KeySignature')):
             description = "Key signature - " + str(count+1) + " of " + str(total) + " is " + self.score.describe_key_signature(ks) + ".  "
             self.time_and_keys.setdefault(ks.measureNumber, []).append(description)
-        
-        self.score.timeSigs = {} # key=bar number.  Value = timeSig   
+
+        self.score.timeSigs = {}  # key=bar number.  Value = timeSig
         previous_ts = self.score.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)[0]
-        
-        #pickup bar
-        if self.score.score.parts[0].getElementsByClass('Measure')[0].number != self.score.score.parts[0].measures(1,2).getElementsByClass('Measure')[0].number:
+
+        # pickup bar
+        if self.score.score.parts[0].getElementsByClass('Measure')[0].number != self.score.score.parts[0].measures(1, 2).getElementsByClass('Measure')[0].number:
             previous_ts = self.score.score.parts[0].getElementsByClass('Measure')[0].getElementsByClass(meter.TimeSignature)[0]
             self.score.timeSigs[0] = previous_ts
-            #todo - where should spanners and dynamics etc go?
-            selected_instruments_descriptions = {} # key = instrument index, {[part descriptions]} 
-            
+            # todo - where should spanners and dynamics etc go?
+            selected_instruments_descriptions = {}  # key = instrument index, {[part descriptions]}
+
             selected_instruments_midis = {}
             for index, ins in enumerate(self.score.selected_instruments):
                 midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=0, range_end=0, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
-                selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
+                selected_instruments_midis[ins] = {"ins": ins,  "midi": midis[0], "midi_parts": midis[1]}
                 selected_instruments_descriptions[ins] = self.score.generate_part_descriptions(instrument=ins, start_bar=0, end_bar=1)
             midiAll = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=0, range_end=0, sel="all")
             midiSelected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=0, range_end=0, sel="sel")
             midiUnselected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=0, range_end=0, sel="un")
-        
-            music_segment = {'start_bar':'0 - pickup', 'end_bar':'0 - pickup', 'selected_instruments_descriptions':selected_instruments_descriptions, 'selected_instruments_midis':selected_instruments_midis,  'midi_all':midiAll, 'midi_sel':midiSelected, 'midi_un':midiUnselected }
+
+            music_segment = {'start_bar': '0 - pickup', 'end_bar': '0 - pickup', 'selected_instruments_descriptions': selected_instruments_descriptions, 'selected_instruments_midis': selected_instruments_midis,  'midi_all': midiAll, 'midi_sel': midiSelected, 'midi_un': midiUnselected}
             music_segments.append(music_segment)
-            number_of_bars-=1
- 
-        #everything except the pickup
-        for bar_index in range( 1, number_of_bars+1, settings['barsAtATime'] ):
+            number_of_bars -= 1
+
+        # everything except the pickup
+        for bar_index in range(1, number_of_bars+1, settings['barsAtATime']):
             end_bar_index = bar_index + settings['barsAtATime'] - 1
             if end_bar_index > number_of_bars:
                 end_bar_index = number_of_bars
-                
-            #cludge to not have None bars - but will actually ignore some...
-            #todo - we get the number of bars just by the length and use that as the maximum bar number.  However- sometimes bars are called "X1" for half bars next to a repeat.  Or Finale re-uses bar numbers for sections - so need a better way of getting each bar...
+
+            # cludge to not have None bars - but will actually ignore some...
+            # todo - we get the number of bars just by the length and use that as the maximum bar number.  However- sometimes bars are called "X1" for half bars next to a repeat.  Or Finale re-uses bar numbers for sections - so need a better way of getting each bar...
             if (self.score.score.parts[0].measure(bar_index) == None):
                 print("start bar is none...")
                 break
-            while (end_bar_index>=1 and self.score.score.parts[0].measure(end_bar_index+1) == None):
-                end_bar_index = end_bar_index -1
+            while (end_bar_index >= 1 and self.score.score.parts[0].measure(end_bar_index+1) == None):
+                end_bar_index = end_bar_index - 1
                 print("end bar index was too big - now " + str(end_bar_index))
             for checkts in range(bar_index, end_bar_index+1):
                 if (self.score.score.parts[0].measure(bar_index) == None):
-                    print ("bar " + str(bar_index) + " is None...")
-                elif len(self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature))>0:
+                    print("bar " + str(bar_index) + " is None...")
+                elif len(self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature)) > 0:
                     previous_ts = self.score.score.parts[0].measure(bar_index).getElementsByClass(meter.TimeSignature)[0]
                 self.score.timeSigs[checkts] = previous_ts
-                
+
             # for offset, events in events_for_bar_range.iteritems():
             # events_ordered_by_beat = OrderedDict(sorted(events_for_bar_range.items(), key=lambda t: t[0]))
 
             # pp = pprint.PrettyPrinter(indent=4)
             # pp.pprint(events_by_bar_and_beat)
 
-            selected_instruments_descriptions = {} # key = instrument index, 
+            selected_instruments_descriptions = {}  # key = instrument index,
             selected_instruments_midis = {}
             for index, ins in enumerate(self.score.selected_instruments):
                 midis = self.score.generate_midi_filenames(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=bar_index, range_end=end_bar_index, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
-                selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
+                selected_instruments_midis[ins] = {"ins": ins,  "midi": midis[0], "midi_parts": midis[1]}
                 selected_instruments_descriptions[ins] = self.score.generate_part_descriptions(instrument=ins, start_bar=bar_index, end_bar=end_bar_index)
-            
+
             midiAll = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=bar_index, range_end=end_bar_index, sel="all")
             midiSelected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=bar_index, range_end=end_bar_index, sel="sel")
             midiUnselected = self.score.generate_midi_filename_sel(prefix="/midis/" + os.path.basename(web_path) + "/", output_path=output_path, range_start=bar_index, range_end=end_bar_index, sel="un")
-        
-            music_segment = {'start_bar':bar_index, 'end_bar': end_bar_index,  'selected_instruments_descriptions':selected_instruments_descriptions, 'selected_instruments_midis':selected_instruments_midis, 'midi_all':midiAll, 'midi_sel':midiSelected, 'midi_un':midiUnselected }
+
+            music_segment = {'start_bar': bar_index, 'end_bar': end_bar_index,  'selected_instruments_descriptions': selected_instruments_descriptions, 'selected_instruments_midis': selected_instruments_midis, 'midi_all': midiAll, 'midi_sel': midiSelected, 'midi_un': midiUnselected}
             music_segments.append(music_segment)
 
         logger.info("End of get_music_segments")
@@ -960,15 +963,13 @@ class HTMLTalkingScoreFormatter():
         return music_segments
 
 
-
-
 if __name__ == '__main__':
-    
+
     # testScoreFilePath = '../talkingscoresapp/static/data/macdowell-to-a-wild-rose.xml'
     testScoreFilePath = '../media/172a28455fa5cfbdaa4eecd5f63a0a2ebaddd92d569980fb402811b9cd5cce4a/MozartPianoSonata.xml'
     # testScoreFilePath = '../talkingscores/talkingscoresapp/static/data/bach-2-part-invention-no-13.xml'
 
-    testScoreOutputFilePath = testScoreFilePath.replace('.xml','.html')
+    testScoreOutputFilePath = testScoreFilePath.replace('.xml', '.html')
 
     testScore = Music21TalkingScore(testScoreFilePath)
     tsf = HTMLTalkingScoreFormatter(testScore)
@@ -977,6 +978,4 @@ if __name__ == '__main__':
     with open(testScoreOutputFilePath, "wb") as fh:
         fh.write(html)
 
-    os.system('open http://0.0.0.0:8000/static/data/%s'%os.path.basename(testScoreOutputFilePath))
-
-
+    os.system('open http://0.0.0.0:8000/static/data/%s' % os.path.basename(testScoreOutputFilePath))

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -725,18 +725,8 @@ class HTMLTalkingScoreFormatter():
             for index, ins in enumerate(self.score.selected_instruments):
                 midis = self.score.generate_midi_for_instruments(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=0, range_end=0, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
                 selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
-               
-            midi_filenames = {}
-            both_hands_midi = self.score.generate_midi_for_part_range(0, 0, output_path=output_path)
-            midi_filenames['both'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(both_hands_midi)
-            left_hand_midi = self.score.generate_midi_for_part_range(0, 0, ['P1-Staff2'], output_path=output_path)
-            right_hand_midi = self.score.generate_midi_for_part_range(0, 0, ['P1-Staff1'], output_path=output_path)
-            if left_hand_midi is not None:
-                midi_filenames['left'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(left_hand_midi)
-            if right_hand_midi is not None:
-                midi_filenames['right'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(right_hand_midi)
 
-            music_segment = {'start_bar':'0 - pickup', 'end_bar':'0 - pickup', 'events_by_bar_and_beat': events_by_bar_and_beat, 'midi_filenames': midi_filenames, 'selected_instruments_midis':selected_instruments_midis }
+            music_segment = {'start_bar':'0 - pickup', 'end_bar':'0 - pickup', 'events_by_bar_and_beat': events_by_bar_and_beat, 'selected_instruments_midis':selected_instruments_midis }
             music_segments.append(music_segment)
             number_of_bars-=1
  
@@ -758,26 +748,7 @@ class HTMLTalkingScoreFormatter():
                 midis = self.score.generate_midi_for_instruments(prefix="/midis/" + os.path.basename(web_path) + "/", range_start=bar_index, range_end=end_bar_index, output_path=output_path, add_instruments=[ins], postfix_filename="ins"+str(index))
                 selected_instruments_midis[ins] = {"ins":ins,  "midi":midis[0], "midi_parts":midis[1]}
             
-
-            midi_filenames = {
-                #'both': os.path.join(web_path, os.path.basename( self.score.generate_midi_for_part_range(bar_index, end_bar_index,output_path=output_path) ) ),
-                # 'right': os.path.join(web_path, os.path.basename( self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff1'],output_path=output_path) ) ),
-            }
-
-            both_hands_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index,
-                                                                     output_path=output_path)
-            midi_filenames['both'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(both_hands_midi)
-                
-            left_hand_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff2'],
-                                                                     output_path=output_path)
-            right_hand_midi = self.score.generate_midi_for_part_range(bar_index, end_bar_index, ['P1-Staff1'],
-                                                                     output_path=output_path)
-            if left_hand_midi is not None:
-                midi_filenames['left'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(left_hand_midi)
-            if right_hand_midi is not None:
-                midi_filenames['right'] = "/midis/" + os.path.basename(web_path) + "/" + os.path.basename(right_hand_midi)
-
-            music_segment = {'start_bar':bar_index, 'end_bar': end_bar_index, 'events_by_bar_and_beat': events_by_bar_and_beat, 'midi_filenames': midi_filenames, 'selected_instruments_midis':selected_instruments_midis }
+            music_segment = {'start_bar':bar_index, 'end_bar': end_bar_index, 'events_by_bar_and_beat': events_by_bar_and_beat, 'selected_instruments_midis':selected_instruments_midis }
             music_segments.append(music_segment)
 
         logger.info("End of get_music_segments")

--- a/lib/talkingscoreslib.py
+++ b/lib/talkingscoreslib.py
@@ -375,6 +375,7 @@ class Music21TalkingScore(TalkingScoreBase):
         return bars_for_parts
 
     def get_events_for_bar_range(self, start_bar, end_bar, part_index):
+        #todo - I have broken multiple voices!
         events_by_bar = {}
         # Iterate over the spanners
         """ 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=2.2.10
 Jinja2==2.10.1
-music21==6.3.0
+music21==7.3.3
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django>=2.2.10
 Jinja2==2.10.1
 music21==7.3.3
 requests==2.22.0
+pathvalidate==3.1.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django>=2.2.10
-Jinja2==2.10.1
-music21==7.3.3
-requests==2.22.0
-pathvalidate==3.1.0
+Django>=4.2.6
+Jinja2==3.0.0
+music21==9.1.0
+requests==2.31.0
+pathvalidate==3.2.0
 

--- a/talkingscores/settings.py
+++ b/talkingscores/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = 'y+-8s4elpz(oge_o42txk#0i5=u9gd0)3q&u+y^+cs#tj9qv1#'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['www.talkingscores.co.uk', '127.0.0.1']
+ALLOWED_HOSTS = ['www.talkingscores.co.uk', 'www.talkingscores.org', '127.0.0.1']
 
 
 # Application definition

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -13,9 +13,18 @@ from talkingscoreslib import Music21TalkingScore, HTMLTalkingScoreFormatter
 #the musicxml file is saved with its original filename - so needs to be sanitized.  Also, we remove apostrophes 
 from pathvalidate import sanitize_filename
 
-log_format = "%(asctime)s - %(levelname)s - %(message)s"
-logging.basicConfig(filename=os.path.join(*(MEDIA_ROOT, "log1.txt")), format=log_format)
 logger = logging.getLogger("TSScore")
+logger.setLevel(logging.DEBUG) #set the minimum level for the logger to the level of the lowest handler or some events could be missed!
+console_handler = logging.StreamHandler()
+file_handler = logging.FileHandler(os.path.join(*(MEDIA_ROOT, "log1.txt")))
+console_handler.setLevel(logging.DEBUG)
+file_handler.setLevel(logging.INFO)
+console_format = logging.Formatter("Ln %(lineno)d - %(message)s")
+file_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+console_handler.setFormatter(console_format)
+file_handler.setFormatter(file_format)
+logger.addHandler(console_handler)
+logger.addHandler(file_handler)
     
 
 def hashfile(afile, hasher, blocksize=65536):
@@ -36,7 +45,6 @@ class TSScore(object):
     
     # I can't seem to find a way of getting the class object in scope at this point to dynamically populate the name
     logger = logging.getLogger("TSScore")
-    logger.level = logging.DEBUG
     def __init__(self, id=None, initial_state=TSScoreState.IDLE, url=None, filename=None):
         self._state = initial_state
         self.url   = url
@@ -122,7 +130,7 @@ class TSScore(object):
             return
 
         temporary_file = tempfile.NamedTemporaryFile(delete=False,dir=os.path.join(BASE_DIR,'tmp'))
-        self.logger.debug("Temporary file: %s" % temporary_file.name)
+        self.logger.info("Temporary file: %s" % temporary_file.name)
         r = requests.get(self.url, stream=True)
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 from urllib.request import url2pathname
 import tempfile
 from talkingscoreslib import Music21TalkingScore, HTMLTalkingScoreFormatter
+#the musicxml file is saved with its original filename - so needs to be sanitized.  Also, we remove apostrophes 
+from pathvalidate import sanitize_filename
 
 log_format = "%(asctime)s - %(levelname)s - %(message)s"
 logging.basicConfig(filename=os.path.join(*(MEDIA_ROOT, "log1.txt")), format=log_format)
@@ -161,8 +163,9 @@ class TSScore(object):
             logger.exception("Unparsable file: %s" % temporary_file.name + " --- " + str(ex))
             raise ex;
 
-        score = TSScore(filename=os.path.basename(uploaded_file.name))
+        score = TSScore(filename=os.path.basename(sanitize_filename(uploaded_file.name.replace("'", "").replace("\"", ""))))
         score.store(temporary_file.name, score.filename)
+        
         return score
 
     @classmethod
@@ -171,6 +174,6 @@ class TSScore(object):
         parsed_url = urlparse(url)
         score = TSScore(url=url)
         score_temp_filepath = score.fetch()
-        score_filename = url2pathname(os.path.basename(parsed_url.path))
+        score_filename = url2pathname(os.path.basename(sanitize_filename(parsed_url.path.name.replace("'", "").replace("\"", "")) ))
         score.store(score_temp_filepath, score_filename)
         return score

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -81,6 +81,12 @@ class TSScore(object):
         # logger.info("File hash is %s" % file_hash)
 
         data_file_path = self.get_data_file_path()
+        ver = 2
+        while os.path.exists(data_file_path) and ver<10:
+            data_file_path = os.path.join(*(MEDIA_ROOT, self.id, ('ver'+str(ver)+"-"+self.filename) )) # removed slashes in directory structure to make files easier to brwose to
+            ver = ver + 1
+        if (ver>2):
+            self.filename=('ver'+str(ver-1)+"-"+self.filename)
 
         try:
             os.rename(src_filepath, data_file_path)

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -69,10 +69,6 @@ class TSScore(object):
             'instruments': score.get_instruments(),
             'number_of_bars': score.get_number_of_bars(),
             'number_of_parts': score.get_number_of_parts(),
-            'repetition_right_hand' : score.music_analyser.repetition_right_hand,
-            'repetition_left_hand' : score.music_analyser.repetition_left_hand,
-            'summary_right_hand' : score.music_analyser.summary_right_hand,
-            'summary_left_hand' : score.music_analyser.summary_left_hand,
         }
 
 

--- a/talkingscoresapp/models.py
+++ b/talkingscoresapp/models.py
@@ -77,7 +77,11 @@ class TSScore(object):
         if self.id is None:
             self.id = hashfile(open(src_filepath, 'rb'), hashlib.sha256())
         if self.filename is None:
+            filename = filename.replace(".xml", ".musicxml")
             self.filename = filename
+        else:
+            self.filename = self.filename.replace(".xml", ".musicxml")
+        
         # logger.info("File hash is %s" % file_hash)
 
         data_file_path = self.get_data_file_path()

--- a/talkingscoresapp/static/css/talkingscores.css
+++ b/talkingscoresapp/static/css/talkingscores.css
@@ -35,6 +35,16 @@ body {
 	color:white !important;
 }
 
+.tsp {
+	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+	font-size: 26px;
+	line-height: 1.4; 
+}
+
+.bold {
+	font-weight: bold;
+}
+
 .loading {
 	-webkit-animation:spin 2s linear infinite;
 	-moz-animation:spin 2s linear infinite;

--- a/talkingscoresapp/static/css/talkingscores.css
+++ b/talkingscoresapp/static/css/talkingscores.css
@@ -11,6 +11,30 @@ body {
 	font-weight: bold;
 }
 
+.navbar-nav li:hover {
+	background-color: blue !important;
+}
+
+.tsactive {
+	color:black !important;
+	background-color:yellow !important;
+	border-bottom:3px solid red !important;
+}
+
+.tsactive:hover {
+	color:white !important;
+	background-color:yellow !important;
+	border-bottom:3px solid red !important;
+}
+
+.tsactive a {
+	color:black !important;
+}
+
+.tsactive a:hover {
+	color:white !important;
+}
+
 .loading {
 	-webkit-animation:spin 2s linear infinite;
 	-moz-animation:spin 2s linear infinite;

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -1,11 +1,15 @@
 {% load static %}
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+    <!-- bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+
+    <!-- Custom styles for this template -->
+    <link href="{% static 'css/talkingscores.css' %}?ver=1005" rel="stylesheet">
+
     <!-- google analytics -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z7G7F9BP8H"></script>
@@ -25,34 +29,32 @@
     
     {% block noindex %}{% endblock %}
 
-    <!-- Bootstrap -->
-    <link href="{% static 'bootstrap-3.3.2-dist/css/bootstrap.min.css' %}" rel="stylesheet">
-
-    <!-- Custom styles for this template -->
-    <link href="{% static 'css/talkingscores.css' %}?ver=1002" rel="stylesheet">
+    
 </head>
 <body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 
-<nav class="navbar navbar-inverse navbar-fixed-top">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"
-                    aria-expanded="false" aria-controls="navbar">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand" href="/">Talking Scores Beta</a>
-        </div>
-        <div id="navbar" class="collapse navbar-collapse">
-            <ul class="nav navbar-nav">
-                <li><a id="lnkHome" href="/">Home</a></li>
-                <li><a href="/change-log">Change Log</a></li>
-                <li><a href="/contact-us">Contact Us</a></li>
+
+<nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Talking Scores Beta</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul id="navbar" class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item mx-2">
+                    <a class="nav-link active" aria-current="page" href="/">Home</a>
+                </li>
+                <li class="nav-item mx-2">
+                    <a class="nav-link active" aria-current="page" href="/change-log">Change Log</a>
+                </li>
+                <li class="nav-item mx-2">
+                    <a class="nav-link active" aria-current="page" href="/contact-us">Contact Us</a>
+                </li>
             </ul>
+          
         </div>
-        <!--/.nav-collapse -->
     </div>
 </nav>
 
@@ -64,19 +66,14 @@
 
 <br/><br/>
 
-<footer class="navbar-inverse">
+<footer class="navbar-dark bg-dark">
     <div class="container">
         
         <div class="row bottom-rule">
-            <div class="text-center py-3"><a style="color:white;" href="/privacy-policy">Privacy Policy</a> </div>
+            <div class="text-center py-1"><a style="color:white;" href="/privacy-policy">Privacy Policy</a> </div>
         </div>
     </div>
 </footer>
-
-
-{#  <main>#}
-{#    <h1>Talking Scores Demo</h1>#}
-{#    <h2></h2>#}
 
 
 <script>

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,7 +29,7 @@
     <link href="{% static 'bootstrap-3.3.2-dist/css/bootstrap.min.css' %}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="{% static 'css/talkingscores.css' %}" rel="stylesheet">
+    <link href="{% static 'css/talkingscores.css' %}?ver=1002" rel="stylesheet">
 </head>
 <body>
 

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -47,7 +47,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                <li class="active"><a href="/">Home</a></li>
+                <li><a id="lnkHome" href="/">Home</a></li>
                 <li><a href="/change-log">Change Log</a></li>
                 <li><a href="/contact-us">Contact Us</a></li>
             </ul>
@@ -79,16 +79,15 @@
 {#    <h2></h2>#}
 
 
-<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-<!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="{% static 'bootstrap-3.3.2-dist/js/bootstrap.min.js' %}"></script>
-
 <script>
-$(document).ready(function() {
-    $('li.active').removeClass('active');
-    $('a[href="' + location.pathname + '"]').closest('li').addClass('active'); 
-  });
+    document.addEventListener("DOMContentLoaded", (event) => {
+        var navLi = document.querySelector('li a[href="' + location.pathname + '"]');
+        if (navLi===null) {
+            navLi = document.querySelector('#lnkHome');
+        }
+        navLi = navLi.closest('li')
+        navLi.classList.add('tsactive');
+    });
 </script>
 
 {#      </main>#}

--- a/talkingscoresapp/templates/base_site.html
+++ b/talkingscoresapp/templates/base_site.html
@@ -8,13 +8,13 @@
     
     <!-- google analytics -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-12637058-8"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z7G7F9BP8H"></script>
     <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-12637058-8');
+    gtag('config', 'G-Z7G7F9BP8H');
     </script>
 
     <title>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,14 @@
             </ul>
         </p>
 
+        <p class="lead"><b>1st March 2023</b><br/>
+            <ul class="lead">
+                <li>Summarise time signature / key signature / tempo changes.</li>
+                <li>Describe time signature and key signature changes in the talking score.  Tempo changes are on the todo list!</li>
+                <li>Describe tempo referent (ie beat length).  Also use it for music segments so playback is at the correct speed.</li>
+            </ul>
+        </p>
+
         <p class="lead"><b>22nd February 2023</b><br/>
             <ul class="lead">
                 <li>Auto summary works on scores with multiple parts.</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,13 @@
             </ul>
         </p>
 
+        <p class="lead"><b>10th October 2023</b><br/>
+            <ul class="lead">
+                <li>Fix crash before options screen if a score doesn't have a key signature</li>
+                <li>Show the error page instead of unfriendly error if a problem occurs before the Options screen</li>
+            </ul>
+        </p>
+
         <p class="lead"><b>22nd July 2023</b><br/>
             <ul class="lead">
                 <li>Fix problems with some filenames</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -22,6 +22,11 @@
             </ul>
         </p>
 
+        <p class="lead"><b>13th February 2022</b><br/>
+            Begun working on scores with multiple parts / instruments.  Choices from the Options page for each score are now passed to the score generator - but they are not particularly acted upon yet.  Added options to play the Selected Instruments and the Unselected Instruments.  If these are selected (and eg if there are any unselected Instruments) then a link is added to the top of outputted score; to play the Selected / Unselected Instruments. <br/><br/>
+            A couple of bug fixes <br/>
+        </p>
+
         <p class="lead"><b>27th June 2021</b><br/>
             Initial release of analysing the score to identify bars (or groups of bars) that have the same pitch and rhythm, or just the same rhythm, or just the same intervals - in order to provide output such as 'Bars 1 to 4 are used almost all of the way through'.<br/> <br/>
             Also attempts to provide a summary of what might be noticeable when glancing at the music; and its distribution throughtout the score - eg 'lots of chords (some Perfect Fifth, almost all minims, mostly 2 notes)' or 'many accidentals (near the end)'. <br/><br/>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -22,19 +22,23 @@
             </ul>
         </p>
 
+        <p class="lead"><b>21st February 2022</b><br/>
+            Added option for phonetic pitch names - Charlie  / Delta / Echo etc.<br/>
+        </p>
+
         <p class="lead"><b>19th February 2022</b><br/>
             Added options for:
         </p><br/>
         <ul class="lead">
             <li>Pitch description - Figure Notes / Note names  / None</li>
-            <li>Rhythm descripion - American / British / None</li>
+            <li>Rhythm description - American / British / None</li>
             <li>Dot - before or after rhythm</li>
-            <li>Rhytm announcement - On change / Every note</li>
+            <li>Rhythm announcement - On change / Every note</li>
             <li>Octave description - Figure Notes / Name / None / Number</li>
             <li>Octave position - before or after note</li>
             <li>Octave announcement - Braille rules / Every note / First note of beat / On change</li>
         </ul>
-        <p class="lead">There is now also the option to use Figure Note colours for the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
+        <p class="lead">There is now also the option to use <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> colours for the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
             The final bar is not omitted from the description! 
         </p>
         

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -19,7 +19,18 @@
             <ul class="lead">
                 <li>This project currently may produce an acceptable output for fairly simple scores - potentially with multiple instruments.</li>
                 <li>At present - most of the testing is carried out using musicxml files exported from MuseScore.</li>
-                <li>If the musicxml file is too large then processing will time out...</li>
+                <li>If the musicxml file is too large - then processing will time out (after about 5 minutes)...</li>
+            </ul>
+        </p>
+
+        <p class="lead"><b>22nd February 2023</b><br/>
+            <ul class="lead">
+                <li>Auto summary works on scores with multiple parts.</li>
+                <li>Auto summary now only mentions repetition if is a significant length instead of listing every time each section is repeated.  It does however, now mention the number of unique bars.</li>
+                <li>Repetition is now described within the score.  Eg this bar was first used at bar 2 and most recently used at bar 7.</li>
+                <li>Describe beat fractions.  Eg beat 1 - dotted crochet.  Beat 2.5 - quaver.</li>
+                <li>Significantly increased the speed of producing a talking score - potentially over twice as fast.</li>
+                <li>Improved the document outline (how headings are nested) - for easier screen reader navigation.</li>
             </ul>
         </p>
 
@@ -28,7 +39,6 @@
                 <li>Each instrument is described separately. </li>
                 <li>If the score has multiple instruments - but you don't select all of them for description - you have the option to listen to All instruments together / All selected instruments together / All unselected instruments together.  This should help to demonstrate how particular instruments fit into the rest of the score.</li>
                 <li>While reading the Talking Score - music segments can be played back at 50% / 100% / 150% speed - with or without a click track / metronome.  This means 6 midi files are created for each single part instrument in each segment.  For a long score with lots of parts - this would take too long and the request would time out...  Therefore, midi files are now created on demand - when the first midi file from a particular segment is requested.</li>
-
             </ul>
         </p>
 

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -16,9 +16,19 @@
         <p class="lead">For more information about specific changes - see the history on <a href="https://github.com/bentimms/talkingscores" target="_blank">Github</a>.</p>
 
         <p class="lead"><b>Current State</b><br/>
-            This project currently may produce an acceptable output for fairly simple piano music - ie one instrument with 2 staves (treble and bass clef).
-            <ul>
-                <li class="lead">Anything other than a single treble stave and a single bass clef stave causes odd results.  In MuseScore - that is a single instrument with two staves.</li>
+            <ul class="lead">
+                <li>This project currently may produce an acceptable output for fairly simple scores - potentially with multiple instruments.</li>
+                <li>At present - most of the testing is carried out using musicxml files exported from MuseScore.</li>
+                <li>If the musicxml file is too large then processing will time out...</li>
+            </ul>
+        </p>
+
+        <p class="lead"><b>17th October 2022</b><br/>
+            <ul class="lead">
+                <li>Each instrument is described separately. </li>
+                <li>If the score has multiple instruments - but you don't select all of them for description - you have the option to listen to All instruments together / All selected instruments together / All unselected instruments together.  This should help to demonstrate how particular instruments fit into the rest of the score.</li>
+                <li>While reading the Talking Score - music segments can be played back at 50% / 100% / 150% speed - with or without a click track / metronome.  This means 6 midi files are created for each single part instrument in each segment.  For a long score with lots of parts - this would take too long and the request would time out...  Therefore, midi files are now created on demand - when the first midi file from a particular segment is requested.</li>
+
             </ul>
         </p>
 

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,18 @@
             </ul>
         </p>
 
+        <p class="tsp"><b>21st January 2024</b><br/>
+            <ul class="tsp">
+                <li>Fixed a crash caused by not being able to read the tempo number</li>
+            </ul>
+        </p>
+
+        <p class="tsp"><b>29th October 2023</b><br/>
+            <ul class="tsp">
+                <li>Upgraded Python version and most of the libaries used by this project to more current versions.  </li>
+            </ul>
+        </p>
+
         <p class="tsp"><b>10th October 2023</b><br/>
             <ul class="tsp">
                 <li>Fix crash before options screen if a score doesn't have a key signature</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -22,9 +22,14 @@
             </ul>
         </p>
 
+        <p class="lead"><b>14th February 2022</b><br/>
+            Mention the dot in dotted rhythms. <br/><br/>
+            Describe unnamed instruments as eg &quot;Instrument 2 (unnamed)&quot;. <br/> 
+        </p>
+
         <p class="lead"><b>13th February 2022</b><br/>
             Begun working on scores with multiple parts / instruments.  Choices from the Options page for each score are now passed to the score generator - but they are not particularly acted upon yet.  Added options to play the Selected Instruments and the Unselected Instruments.  If these are selected (and eg if there are any unselected Instruments) then a link is added to the top of outputted score; to play the Selected / Unselected Instruments. <br/><br/>
-            A couple of bug fixes <br/>
+            A couple of bug fixes. <br/>
         </p>
 
         <p class="lead"><b>27th June 2021</b><br/>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,13 @@
             </ul>
         </p>
 
+        <p class="lead"><b>11th June 2023</b><br/>
+            <ul class="lead">
+                <li>Tuplets are now described</li>
+                <li>Temporary fix to stop error when scores have non-sequential bar numbers.  Eg pickup bars after a repeat might be numbered differently.  These bars are not described yet - but at least they won't cause an error!</li>
+            </ul>
+        </p>
+
         <p class="lead"><b>1st March 2023</b><br/>
             <ul class="lead">
                 <li>Summarise time signature / key signature / tempo changes.</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -7,53 +7,53 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <div class="col-md-8 col-md-offset-2 text-left">
+    <div class="col-md-11 mx-auto text-start">
 
         <h2>Change Log</h2>
 
-        <p class="lead">This page details various updates made to this project.  The dates represent the approximate date when particular changes were committed in Git.  The actual date that the changes became live on this site will most likely be different.  Progress is gradually being made - so please do retry files that may not have worked before.</p>
+        <p class="tsp">This page details various updates made to this project.  The dates represent the approximate date when particular changes were committed in Git.  The actual date that the changes became live on this site will most likely be different.  Progress is gradually being made - so please do retry files that may not have worked before.</p>
 
-        <p class="lead">For more information about specific changes - see the history on <a href="https://github.com/bentimms/talkingscores" target="_blank">Github</a>.</p>
+        <p class="tsp">For more information about specific changes - see the history on <a href="https://github.com/bentimms/talkingscores" target="_blank">Github</a>.</p>
 
-        <p class="lead"><b>Current State</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>Current State</b><br/>
+            <ul class="tsp">
                 <li>This project currently may produce an acceptable output for fairly simple scores - potentially with multiple instruments.</li>
                 <li>At present - most of the testing is carried out using musicxml files exported from MuseScore.</li>
                 <li>If the musicxml file is too large - then processing will time out (after about 5 minutes)...</li>
             </ul>
         </p>
 
-        <p class="lead"><b>10th October 2023</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>10th October 2023</b><br/>
+            <ul class="tsp">
                 <li>Fix crash before options screen if a score doesn't have a key signature</li>
                 <li>Show the error page instead of unfriendly error if a problem occurs before the Options screen</li>
             </ul>
         </p>
 
-        <p class="lead"><b>22nd July 2023</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>22nd July 2023</b><br/>
+            <ul class="tsp">
                 <li>Fix problems with some filenames</li>
                 <li>Imrpoved text on home page</li>
             </ul>
         </p>
 
-        <p class="lead"><b>11th June 2023</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>11th June 2023</b><br/>
+            <ul class="tsp">
                 <li>Tuplets are now described</li>
                 <li>Temporary fix to stop error when scores have non-sequential bar numbers.  Eg pickup bars after a repeat might be numbered differently.  These bars are not described yet - but at least they won't cause an error!</li>
             </ul>
         </p>
 
-        <p class="lead"><b>1st March 2023</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>1st March 2023</b><br/>
+            <ul class="tsp">
                 <li>Summarise time signature / key signature / tempo changes.</li>
                 <li>Describe time signature and key signature changes in the talking score.  Tempo changes are on the todo list!</li>
                 <li>Describe tempo referent (ie beat length).  Also use it for music segments so playback is at the correct speed.</li>
             </ul>
         </p>
 
-        <p class="lead"><b>22nd February 2023</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>22nd February 2023</b><br/>
+            <ul class="tsp">
                 <li>Auto summary works on scores with multiple parts.</li>
                 <li>Auto summary now only mentions repetition if is a significant length instead of listing every time each section is repeated.  It does however, now mention the number of unique bars.</li>
                 <li>Repetition is now described within the score.  Eg this bar was first used at bar 2 and most recently used at bar 7.</li>
@@ -63,26 +63,26 @@
             </ul>
         </p>
 
-        <p class="lead"><b>17th October 2022</b><br/>
-            <ul class="lead">
+        <p class="tsp"><b>17th October 2022</b><br/>
+            <ul class="tsp">
                 <li>Each instrument is described separately. </li>
                 <li>If the score has multiple instruments - but you don't select all of them for description - you have the option to listen to All instruments together / All selected instruments together / All unselected instruments together.  This should help to demonstrate how particular instruments fit into the rest of the score.</li>
                 <li>While reading the Talking Score - music segments can be played back at 50% / 100% / 150% speed - with or without a click track / metronome.  This means 6 midi files are created for each single part instrument in each segment.  For a long score with lots of parts - this would take too long and the request would time out...  Therefore, midi files are now created on demand - when the first midi file from a particular segment is requested.</li>
             </ul>
         </p>
 
-        <p class="lead"><b>19th April 2022</b><br/>
+        <p class="tsp"><b>19th April 2022</b><br/>
             Creates MIDI files for each instrument and each part (or hand) if the instrument has multiple clefs.  Still needs a bit of tidying up etc.<br/>
         </p>
 
-        <p class="lead"><b>21st February 2022</b><br/>
+        <p class="tsp"><b>21st February 2022</b><br/>
             Added option for phonetic pitch names - Charlie  / Delta / Echo etc.<br/>
         </p>
 
-        <p class="lead"><b>19th February 2022</b><br/>
+        <p class="tsp"><b>19th February 2022</b><br/>
             Added options for:
         </p><br/>
-        <ul class="lead">
+        <ul class="tsp">
             <li>Pitch description - Colour / Note names  / None</li>
             <li>Rhythm description - American / British / None</li>
             <li>Dot - before or after rhythm</li>
@@ -91,72 +91,72 @@
             <li>Octave position - before or after note</li>
             <li>Octave announcement - Braille rules / Every note / First note of beat / On change</li>
         </ul>
-        <p class="lead">There is now also the option to set the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
+        <p class="tsp">There is now also the option to set the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
             The final bar is not omitted from the description! 
         </p>
         
-        <p class="lead"><b>14th February 2022</b><br/>
+        <p class="tsp"><b>14th February 2022</b><br/>
             Mention the dot in dotted rhythms. <br/><br/>
             Describe unnamed instruments as eg &quot;Instrument 2 (unnamed)&quot;. <br/> 
         </p>
 
-        <p class="lead"><b>13th February 2022</b><br/>
+        <p class="tsp"><b>13th February 2022</b><br/>
             Begun working on scores with multiple parts / instruments.  Choices from the Options page for each score are now passed to the score generator - but they are not particularly acted upon yet.  Added options to play the Selected Instruments and the Unselected Instruments.  If these are selected (and eg if there are any unselected Instruments) then a link is added to the top of outputted score; to play the Selected / Unselected Instruments. <br/><br/>
             A couple of bug fixes. <br/>
         </p>
 
-        <p class="lead"><b>27th June 2021</b><br/>
+        <p class="tsp"><b>27th June 2021</b><br/>
             Initial release of analysing the score to identify bars (or groups of bars) that have the same pitch and rhythm, or just the same rhythm, or just the same intervals - in order to provide output such as 'Bars 1 to 4 are used almost all of the way through'.<br/> <br/>
             Also attempts to provide a summary of what might be noticeable when glancing at the music; and its distribution throughtout the score - eg 'lots of chords (some Perfect Fifth, almost all minims, mostly 2 notes)' or 'many accidentals (near the end)'. <br/><br/>
             The lists of repeating bars / groups are not very easy to read at present (especially as they are shown the Score Options page as opposed to the actual Talking Score output page) - so in a later update, they will probably be moved into the main description as eg 'first used at bar 5; most recently used at bar 9'. <br/>
         </p>
 
-        <p class="lead"><b>28th December 2020</b><br/>
+        <p class="tsp"><b>28th December 2020</b><br/>
             Upgraded Music21 from 5.5.0 to 6.3.0.  One of the benefits is increased performance when creating MIDI files.</p>
 
-        <p class="lead"><b>1st December 2020</b><br/>
+        <p class="tsp"><b>1st December 2020</b><br/>
             Grace notes are described - but maybe not played correctly.<br/>
             Note ornaments / expressions are described - just using Music21 names so may need to elaborate the description. </p>
         
-        <p class="lead"><b>2nd September 2020</b><br/>
+        <p class="tsp"><b>2nd September 2020</b><br/>
             Rests are now described.<br/>
             Semibreves are no longer described as &quot;Unkown duration&quot;. </p>
         
-        <p class="lead"><b>31st August 2020</b><br/>
+        <p class="tsp"><b>31st August 2020</b><br/>
             If the score has a pickup bar / anacrusis - it is included in the output.</p>
         
-        <p class="lead"><b>30th August 2020</b><br/>
+        <p class="tsp"><b>30th August 2020</b><br/>
             The developers are now notified if an error occurs and the user requests to be notified by email when this is fixed.</p>
         
-        <p class="lead"><b>25th May 2020</b><br/>
+        <p class="tsp"><b>25th May 2020</b><br/>
             If there are no tempo changes at the start of a segment - MIDI files now include the last tempo chnage before the segment.  <br/>
             For example, if there is a tempo mark of 80 bpm in bar 5 and no other tempo changes in the score.  If you play bars 8 to 11, the MIDI file will include the tempo change from bar 5 at the start; so that bars 8 to 11 will play at the correct speed.</p>
 
-        <p class="lead"><b>26th April 2020</b><br/>
+        <p class="tsp"><b>26th April 2020</b><br/>
             Added Change Log, Contact Us and Privacy Policy pages with basic title and description for SEO purposes.</p>
 
-        <p class="lead"><b>22nd April 2020</b><br/>
+        <p class="tsp"><b>22nd April 2020</b><br/>
             Fixed error when long name for Dynamics is not known.</p>
 
-        <p class="lead"><b>19th April 2020</b><br/>
+        <p class="tsp"><b>19th April 2020</b><br/>
             Tempos are inserted in midi files for the 2nd stave.  <b>To-do:</b> - insert current tempo at the start of segments.</p>
     
-        <p class="lead"><b>13th April 2020</b><br/>
+        <p class="tsp"><b>13th April 2020</b><br/>
             Added Google Analytics.  Configured robots.txt and noindex so that completed scores are not indexed or tracked.</p>
     
-        <p class="lead"><b>5th April 2020</b><br/>
+        <p class="tsp"><b>5th April 2020</b><br/>
             Fixed CORS error so that midi files are played - ie we can listen to the score - or sections of it.</p>
 
-        <p class="lead"><b>19th January 2020</b><br/>
+        <p class="tsp"><b>19th January 2020</b><br/>
             Use 'bars at a time' from Options screen.</p>
     
-        <p class="lead"><b>28th July 2019</b><br/>
+        <p class="tsp"><b>28th July 2019</b><br/>
             Fixed 'unknown duration' for notes smaller than quavers.</p>
 
-        <p class="lead"><b>27th July 2019</b><br/>
+        <p class="tsp"><b>27th July 2019</b><br/>
             Fixed key signature in preamble.</p>
 
-        <p class="lead"><b>21st July 2019</b><br/>
+        <p class="tsp"><b>21st July 2019</b><br/>
             Fixed pitch ordering within beats and chords.</p>
     
     </div>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Change Log - Talking Scores (Beta){% endblock %}
 {% block meta-description %}Overview of updates to Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -22,6 +22,22 @@
             </ul>
         </p>
 
+        <p class="lead"><b>19th February 2022</b><br/>
+            Added options for:
+        </p><br/>
+        <ul class="lead">
+            <li>Pitch description - Figure Notes / Note names  / None</li>
+            <li>Rhythm descripion - American / British / None</li>
+            <li>Dot - before or after rhythm</li>
+            <li>Rhytm announcement - On change / Every note</li>
+            <li>Octave description - Figure Notes / Name / None / Number</li>
+            <li>Octave position - before or after note</li>
+            <li>Octave announcement - Braille rules / Every note / First note of beat / On change</li>
+        </ul>
+        <p class="lead">There is now also the option to use Figure Note colours for the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
+            The final bar is not omitted from the description! 
+        </p>
+        
         <p class="lead"><b>14th February 2022</b><br/>
             Mention the dot in dotted rhythms. <br/><br/>
             Describe unnamed instruments as eg &quot;Instrument 2 (unnamed)&quot;. <br/> 

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,15 @@
             </ul>
         </p>
 
+        <p class="tsp"><b>28th January 2024</b><br/>
+            <ul class="tsp">
+                <li>Fix a crash trying to read the title of some scores</li>
+                <li>Describe unpitched notes - instead of crashing</li>
+                <li>Fix errors in description and summarisation when the score only had one bar</li>
+                <li>Fix crash when a score doesn't have a time signature</li>
+            </ul>
+        </p>
+
         <p class="tsp"><b>21st January 2024</b><br/>
             <ul class="tsp">
                 <li>Fixed a crash caused by not being able to read the tempo number</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -23,6 +23,13 @@
             </ul>
         </p>
 
+        <p class="lead"><b>22nd July 2023</b><br/>
+            <ul class="lead">
+                <li>Fix problems with some filenames</li>
+                <li>Imrpoved text on home page</li>
+            </ul>
+        </p>
+
         <p class="lead"><b>11th June 2023</b><br/>
             <ul class="lead">
                 <li>Tuplets are now described</li>

--- a/talkingscoresapp/templates/change-log.html
+++ b/talkingscoresapp/templates/change-log.html
@@ -22,6 +22,10 @@
             </ul>
         </p>
 
+        <p class="lead"><b>19th April 2022</b><br/>
+            Creates MIDI files for each instrument and each part (or hand) if the instrument has multiple clefs.  Still needs a bit of tidying up etc.<br/>
+        </p>
+
         <p class="lead"><b>21st February 2022</b><br/>
             Added option for phonetic pitch names - Charlie  / Delta / Echo etc.<br/>
         </p>
@@ -30,15 +34,15 @@
             Added options for:
         </p><br/>
         <ul class="lead">
-            <li>Pitch description - Figure Notes / Note names  / None</li>
+            <li>Pitch description - Colour / Note names  / None</li>
             <li>Rhythm description - American / British / None</li>
             <li>Dot - before or after rhythm</li>
             <li>Rhythm announcement - On change / Every note</li>
-            <li>Octave description - Figure Notes / Name / None / Number</li>
+            <li>Octave description - Name / None / Number</li>
             <li>Octave position - before or after note</li>
             <li>Octave announcement - Braille rules / Every note / First note of beat / On change</li>
         </ul>
-        <p class="lead">There is now also the option to use <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> colours for the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
+        <p class="lead">There is now also the option to set the text colour or background colour of pitches / octaves / rhythms.<br/> <br/> 
             The final bar is not omitted from the description! 
         </p>
         

--- a/talkingscoresapp/templates/contact-us.html
+++ b/talkingscoresapp/templates/contact-us.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Contact Us - Talking Scores (Beta){% endblock %}
 {% block meta-description %}We welcome your comments / questions / bug reports - Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}

--- a/talkingscoresapp/templates/contact-us.html
+++ b/talkingscoresapp/templates/contact-us.html
@@ -7,15 +7,15 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <div class="col-md-8 col-md-offset-2 text-left">
+    <div class="col-md-11 mx-auto text-start">
 
         <h2>Contact Us</h2>
 
-        <p class="lead">Please do feel free to contact us with questions / bug reports / feature requests etc - or even just to let us know if you find this project useful!  It is encouraging to hear from users - thank you!</p>
+        <p class="tsp">Please do feel free to contact us with questions / bug reports / feature requests etc - or even just to let us know if you find this project useful!  It is encouraging to hear from users - thank you!</p>
 
-        <p class="lead">Our email address is <a href="mailto:talkingscores@gmail.com">talkingscores@gmail.com</a></p>
+        <p class="tsp">Our email address is <a href="mailto:talkingscores@gmail.com">talkingscores@gmail.com</a></p>
 
-        <p class="lead">If you choose to contact us, we will try to reply in a timely manner.  We will most likely contact you again, some time later, when we have addressed your question more fully. <br/>
+        <p class="tsp">If you choose to contact us, we will try to reply in a timely manner.  We will most likely contact you again, some time later, when we have addressed your question more fully. <br/>
             We will not pass your contact details on to anyone else or use them for any other purpose.  For more information - see our <a href="/privacy-policy">Privacy Policy</a>.
         </p>    
     </div>

--- a/talkingscoresapp/templates/error.html
+++ b/talkingscoresapp/templates/error.html
@@ -15,7 +15,7 @@
             <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
             <span class="sr-only">Warning:</span>
             I'm sorry to say that we had trouble processing this score. The development team has been
-            notified and will look into how to fix this.
+            notified and will look into how to fix this.  Please do Contact Us by email or with the form below, if you would like to be notified when this is fixed.  Or come back occasionally and check the Change Log Page - often an error will be fixed in the next update.   
         </div>
 
         <p class="tsp">If you'd like to be notified when this score is working, simply put your email address in the box below. We
@@ -37,8 +37,7 @@
                     {% else %}
                         <strong>Invalid email address</strong>
                     {% endif %}
-                    <br/>Please do enter a valid email address if you'd like to be notified about this score. Honestly,
-                    we don't do anything nefarious with it.
+                    <br/>Please do enter a valid email address if you'd like to be notified about this score. 
                 </div>
             {% endif %}
         {% endif %}

--- a/talkingscoresapp/templates/error.html
+++ b/talkingscoresapp/templates/error.html
@@ -49,7 +49,7 @@
                 <input type="email" class="form-control" name="notify_email" id="id_notify_email"
                        placeholder="Email address">
             </div>
-            <button type="submit" class="btn btn-default">Notify me</button>
+            <button type="submit" class="btn btn-primary btn-lg">Notify me</button>
         </form>
 
     </div>

--- a/talkingscoresapp/templates/error.html
+++ b/talkingscoresapp/templates/error.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Error producing Talking Score - Talking Scores (Beta){% endblock %}
 {% block noindex %}<meta name="robots" content="noindex" />{% endblock %}

--- a/talkingscoresapp/templates/error.html
+++ b/talkingscoresapp/templates/error.html
@@ -7,31 +7,31 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <div class="col-md-8 col-md-offset-2 text-left">
+    <div class="col-md-11 mx-auto text-start">
 
         <h3>Oops!</h3>
 
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning tsp" role="alert">
             <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
             <span class="sr-only">Warning:</span>
             I'm sorry to say that we had trouble processing this score. The development team has been
             notified and will look into how to fix this.
         </div>
 
-        <p>If you'd like to be notified when this score is working, simply put your email address in the box below. We
+        <p class="tsp">If you'd like to be notified when this score is working, simply put your email address in the box below. We
             promise to only use your email address to notify you about this score.</p>
 
         {#        {{ form }}#}
 
         {% if form.is_bound %}
             {% if form.is_valid %}
-                <div class="alert alert-success">
+                <div class="alert alert-success tsp">
                     <strong>Thank you!</strong>
                     We have made a note of your email address and will let you know when we've investigated why this score
                     isn't working.
                 </div>
             {% else %}
-                <div class="alert alert-danger">
+                <div class="alert alert-danger tsp">
                     {% if form.errors.notify_email.0 == 'This field is required.' %}
                         <strong>Missing email address</strong>
                     {% else %}
@@ -45,7 +45,7 @@
 
         <form action="{% url 'error' id filename %}" method="post">
             {% csrf_token %}
-            <div class="form-group">
+            <div class="form-group tsp">
                 <label for="notify_email">Email address</label>
                 <input type="email" class="form-control" name="notify_email" id="id_notify_email"
                        placeholder="Email address">

--- a/talkingscoresapp/templates/index.html
+++ b/talkingscoresapp/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Talking Scores (Beta) - making musicXML files more accessible{% endblock %}
 {% block meta-description %}Open source project to convert MusicXML files to a spoken description with audio segments - to make sheet music more accessible to print impaired musicians {% endblock %}

--- a/talkingscoresapp/templates/index.html
+++ b/talkingscoresapp/templates/index.html
@@ -7,11 +7,11 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <p class="lead">A Talking Score is a spoken representation of stave notation; often with recordings of the music being described.  They are designed to assist print impaired musicians to use sheet music. </p>
+    <p class="lead">Talking Scores are a spoken representation of stave notation; often with recordings of the music being described.  They are designed to assist print impaired musicians to use sheet music. </p>
 
-    <p class="lead">Producing a talking score manually can be time consuming, is often not a straightforward process and may require aspects tailored to individual musicians.  This website aims to automatically produce a talking score from a MusicXML file.  </p> 
+    <p class="lead">Producing a talking score manually can be time consuming, is often not a straightforward process and may require aspects tailored to individual musicians.  This website aims to automatically produce a talking score from a MusicXML file.  It will produce a representation of the score as text along with audio for the music; but you will need to use a screen reader to get the &quot;talking&quot; aspect of the Talking Score.</p> 
         
-    <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  It is a work in progress and has many known issues - and probably many unknown issues too!  Please see the <a href="/change-log">Change Log</a> for latest updates or <a href="/contact-us">contact us</a> with questions / feature requests etc. </p>
+    <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  It is a work in progress and therefore may not always work correctly.  Please see the <a href="/change-log">Change Log</a> for latest updates or <a href="/contact-us">contact us</a> with questions / problems / feature requests etc. </p>
     <hr>
 
     <h3><b>Upload or provide a URL to a MusicXML file.</b></h3>

--- a/talkingscoresapp/templates/index.html
+++ b/talkingscoresapp/templates/index.html
@@ -40,8 +40,7 @@
             <label for="id_url" class="col-sm-3 control-label">URL</label>
 
             <div class="col-sm-6">
-                <input type="url" class="form-control input-lg" id="id_url" name="url"
-                       placeholder="http://beta.talkingscores.org/scores/macdowell-to-a-wild-rose.xml">
+                <input type="url" class="form-control input-lg" id="id_url" name="url">
             </div>
         </div>
         <div class="form-group">

--- a/talkingscoresapp/templates/index.html
+++ b/talkingscoresapp/templates/index.html
@@ -5,58 +5,62 @@
 {% block meta-description %}Open source project to convert MusicXML files to a spoken description with audio segments - to make sheet music more accessible to print impaired musicians {% endblock %}
 
 {% block content %}
-    <h1>Talking Scores Beta</h1>
+        <h1>Talking Scores Beta</h1>
 
-    <p class="lead">Talking Scores are a spoken representation of stave notation; often with recordings of the music being described.  They are designed to assist print impaired musicians to use sheet music. </p>
+        <div class="col-md-11 mx-auto text-start">
+            <p class="tsp">Talking Scores are a spoken representation of stave notation; often with recordings of the music being described.  They are designed to assist print impaired musicians to use sheet music. </p>
 
-    <p class="lead">Producing a talking score manually can be time consuming, is often not a straightforward process and may require aspects tailored to individual musicians.  This website aims to automatically produce a talking score from a MusicXML file.  It will produce a representation of the score as text along with audio for the music; but you will need to use a screen reader to get the &quot;talking&quot; aspect of the Talking Score.</p> 
-        
-    <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  It is a work in progress and therefore may not always work correctly.  Please see the <a href="/change-log">Change Log</a> for latest updates or <a href="/contact-us">contact us</a> with questions / problems / feature requests etc. </p>
-    <hr>
+            <p class="tsp">Producing a talking score manually can be time consuming, is often not a straightforward process and may require aspects tailored to individual musicians.  This website aims to automatically produce a talking score from a MusicXML file.  It will produce a representation of the score as text along with audio for the music; but you will need to use a screen reader to get the &quot;talking&quot; aspect of the Talking Score.</p> 
+                
+            <p class="tsp">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  It is a work in progress and therefore may not always work correctly.  Please see the <a href="/change-log">Change Log</a> for latest updates or <a href="/contact-us">contact us</a> with questions / problems / feature requests etc. </p>      
+        </div>
+                
+        <hr>
 
-    <h3><b>Upload or provide a URL to a MusicXML file.</b></h3>
+        <h3><b>Upload or provide a URL to a MusicXML file.</b></h3>
 
-    <form class="form-horizontal" action="{% url 'index' %}" method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {% if form.non_field_errors %}
-            {% for error in form.non_field_errors %}
-                <div class="alert alert-danger" role="alert">
-                    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                    {{ error }}
+        <form class="form-horizontal text-center mx-auto" action="{% url 'index' %}" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {% if form.non_field_errors %}
+                {% for error in form.non_field_errors %}
+                    <div class="alert alert-danger" role="alert">
+                        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                        {{ error }}
+                    </div>
+                {% endfor %}
+            {% endif %}
+            <div class="form-group mx-auto">
+                <label for="id_filename" class="col-sm-3 control-label">Upload</label>
+
+                <div class="col-sm-6 mx-auto">
+                    <input type="file" class="form-control input-lg mx-auto" id="id_filename" name="filename">
                 </div>
+            </div>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-6 mx-auto"><p class="tsp">or</p></div>
+            </div>
+            <div class="form-group">
+                <label for="id_url" class="col-sm-3 control-label">URL</label>
+
+                <div class="col-sm-6 mx-auto">
+                    <input type="url" class="form-control input-lg " id="id_url" name="url">
+                </div>
+            </div>
+            <br/>
+            <div class="form-group">
+                <div class="col-sm-offset-3 col-sm-6 mx-auto">
+                    <button type="submit" class="btn btn-primary btn-lg">Generate Talking Score</button>
+                </div>
+            </div>
+        </form>
+
+        <hr>
+        <h3><b>Example scores</b></h3>
+        <p class="tsp">These example scores have been produced by this website and should give a good idea of what a Talking Score is.  They might not have been produced by the latest version of the code.</p>
+        <ul class="list-unstyled">
+            {% for example_score in example_scores %}
+                <li class="tsp"><a href="{% static 'data/' %}{{ example_score }}">{{ example_score }}</a></li> <br/>
             {% endfor %}
-        {% endif %}
-        <div class="form-group">
-            <label for="id_filename" class="col-sm-3 control-label">Upload</label>
-
-            <div class="col-sm-6">
-                <input type="file" class="form-control input-lg" id="id_filename" name="filename">
-            </div>
+        </ul>
         </div>
-        <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-6"><p class="lead">or</p></div>
-        </div>
-        <div class="form-group">
-            <label for="id_url" class="col-sm-3 control-label">URL</label>
-
-            <div class="col-sm-6">
-                <input type="url" class="form-control input-lg" id="id_url" name="url">
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="col-sm-offset-3 col-sm-6">
-                <button type="submit" class="btn btn-primary btn-lg">Generate Talking Score</button>
-            </div>
-        </div>
-    </form>
-
-    <hr>
-    <h3><b>Example scores</b></h3>
-    <p class="lead">These example scores have been produced by this website and should give a good idea of what a Talking Score is.  They might not have been produced by the latest version of the code.</p>
-    <ul class="list-unstyled">
-        {% for example_score in example_scores %}
-            <li class="lead"><a href="{% static 'data/' %}{{ example_score }}">{{ example_score }}</a></li>
-        {% endfor %}
-    </ul>
-    </div>
 {% endblock content %}

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Options - Talking Scores (Beta){% endblock %}
 {% block noindex %}<meta name="robots" content="noindex" />{% endblock %}

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -94,7 +94,7 @@
                     <label for="bars_at_a_time">Bars at a time</label>
                     <select name="bars_at_a_time" id="bars_at_a_time" class="form-control">
                         <option>1</option>
-                        <option>2</option>
+                        <option selected>2</option>
                         <option>4</option>
                         <option>8</option>
                     </select>

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -105,8 +105,9 @@
                         <option value="figureNotes">Figure Notes (red / brown)</option>
                         <option value="noteName" selected>Note names (C / D)</option>
                         <option value="none">None</option>
+                        <option value="phonetic">Phonetic (Charlie / Delta)</option>
                     </select>
-                    No pitch description might be of interest when using Figure Note coloured output.
+                    <p class="lead">Setting the pitch description to &quot;None&quot;, might be of interest when using <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> coloured output.</p>
                     <br/><br/>
 
                     <label for="rhythm_description">Rhythm description</label>
@@ -157,7 +158,8 @@
                     <br/><br/>
                 </div>
 
-                <h3>Coloured output (Figure Notes):</h3>
+                <h3>Coloured output:</h3>
+                <p class="lead">Set the text colour or background colour of parts of the description to use <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> colours.</p>
                 <div class="form-group">
                     <label for="colour_position">Colour position</label>
                     <select name="colour_position" id="colour_position" class="form-control">

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -102,12 +102,12 @@
 
                     <label for="pitch_description">Pitch description</label>
                     <select name="pitch_description" id="pitch_description" class="form-control">
-                        <option value="figureNotes">Figure Notes (red / brown)</option>
+                        <option value="colourNotes">Coloured Notes (red / brown)</option>
                         <option value="noteName" selected>Note names (C / D)</option>
                         <option value="none">None</option>
                         <option value="phonetic">Phonetic (Charlie / Delta)</option>
                     </select>
-                    <p class="lead">Setting the pitch description to &quot;None&quot;, might be of interest when using <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> coloured output.</p>
+                    <p class="lead">Setting the pitch description to &quot;None&quot;, might be of interest when using coloured text.</p>
                     <br/><br/>
 
                     <label for="rhythm_description">Rhythm description</label>
@@ -134,7 +134,6 @@
 
                     <label for="octave_description">Octave description</label>
                     <select name="octave_description" id="octave_description" class="form-control">
-                        <option value="figureNotes">Figure Notes (circle / triangle)</option>
                         <option value="name" selected>Name (mid / high)</option>
                         <option value="none">None</option>
                         <option value="number">Number (4 / 5)</option>
@@ -159,7 +158,7 @@
                 </div>
 
                 <h3>Coloured output:</h3>
-                <p class="lead">Set the text colour or background colour of parts of the description to use <a href="https://figurenotes.org/" target="_blank">Figure Notes</a> colours.</p>
+                <p class="lead">Set the text colour or background colour of parts of the description to use colours.</p>
                 <div class="form-group">
                     <label for="colour_position">Colour position</label>
                     <select name="colour_position" id="colour_position" class="form-control">

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -39,20 +39,6 @@
         </div>
     </div>
 
-    <h1>Summary:</h1>
-    <div class="row text-left">
-        <div class="col-md-6 col-md-offset-3">
-            <p class="lead">Right hand: {{score_info.summary_right_hand}}</p>
-            <p class="lead">Left hand: {{score_info.summary_left_hand}}</p>
-        </div>
-    </div>
-    
-    <h1>Repetition:</h1>
-    <div class="row text-left">
-        <div class="col-md-6 col-md-offset-3">        <p class="lead">Right hand: {{score_info.repetition_right_hand}}</p>
-            <p class="lead">Left hand: {{score_info.repetition_left_hand}}</p>
-        </div>
-    </div>
     <h1>Options</h1>
     
     <div class="row text-left">

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -5,24 +5,24 @@
 {% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
+    <div class="col-md-9 mx-auto text-start">
 
-    {% if form.non_field_errors %}
-        <div class="alert alert-danger" role="alert">
-            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            {{ form.non_field_errors }}
-        </div>
-    {% endif %}
+        {% if form.non_field_errors %}
+            <div class="alert alert-danger" role="alert">
+                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                {{ form.non_field_errors }}
+            </div>
+        {% endif %}
 
-    {% if form.errors %}
-        <div class="alert alert-danger" role="alert">
-            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            {{ form.errors }}
-        </div>
-    {% endif %}
+        {% if form.errors %}
+            <div class="alert alert-danger" role="alert">
+                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                {{ form.errors }}
+            </div>
+        {% endif %}
 
-    <h1>Detected features:</h1>
-    <div class="row text-left lead">
-        <div class="col-md-6 col-md-offset-3">
+        <h1 class="text-center">Detected features:</h1>
+        <div class="tsp">
             <ul class="list-unstyled">
                 <li>{{ score_info.title }} by {{ score_info.composer }}</li>
                 <li>{{ score_info.instruments|length }} instrument{{ score_info.instruments|length|pluralize }}:
@@ -37,17 +37,15 @@
                 <li>{{ score_info.number_of_bars }} bars</li>
             </ul>
         </div>
-    </div>
 
-    <h1>Options</h1>
-    
-    <div class="row text-left">
-        <div class="col-md-6 col-md-offset-3">
-            
+        <h1 class="text-center">Options</h1>
+        
+        <div class="tsp">
+                
             <form class="form-horizontal" method="post">
                 {% csrf_token %}
                 
-                <h3>Play parts:</h3>
+                <h2 class="bold">Play parts:</h2>
                 <div id="" class="form-group">
                     <div class="checkbox">
                         <input type="checkbox" name="chk_playAll" id="chk_playAll" value="checked" checked="checked" aria-label="Play all parts together"/>
@@ -62,8 +60,9 @@
                         <label for="chk_playUnselected">Play all not selected parts together</label>
                     </div>
                 </div>
-    
-                <h3>Selected instruments:</h3>
+                <br>
+
+                <h2 class="bold">Selected instruments:</h2>
                 <div id="" class="form-group">                    
                     {% for instrument in score_info.instruments %}
                         <div class="checkbox">
@@ -74,8 +73,9 @@
                         </div>
                     {% endfor %}
                 </div>
+                <br/>
 
-                <h3>Description:</h3>
+                <h2 class="bold">Description:</h2>
                 <div class="form-group">
                     <label for="bars_at_a_time">Bars at a time</label>
                     <select name="bars_at_a_time" id="bars_at_a_time" class="form-control">
@@ -84,7 +84,7 @@
                         <option>4</option>
                         <option>8</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="pitch_description">Pitch description</label>
                     <select name="pitch_description" id="pitch_description" class="form-control">
@@ -93,8 +93,8 @@
                         <option value="none">None</option>
                         <option value="phonetic">Phonetic (Charlie / Delta)</option>
                     </select>
-                    <p class="lead">Setting the pitch description to &quot;None&quot;, might be of interest when using coloured text.</p>
-                    <br/><br/>
+                    <p>Setting the pitch description to &quot;None&quot;, might be of interest when using coloured text.</p>
+                    <br/>
 
                     <label for="rhythm_description">Rhythm description</label>
                     <select name="rhythm_description" id="rhythm_description" class="form-control">
@@ -102,21 +102,21 @@
                         <option value="british" selected>British (crotchet etc)</option>
                         <option value="none">None</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="dot_position">Position of dot in dotted rhythms</label>
                     <select name="dot_position" id="dot_position" class="form-control">
                         <option value="before" selected>Before rhythm</option>
                         <option value="after">After rhythm</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="rhythm_announcement">Rhythm announcement</label>
                     <select name="rhythm_announcement" id="rhythm_announcement" class="form-control">
                         <option value="everyNote">Every note</option>
                         <option value="onChange" selected>On change</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="octave_description">Octave description</label>
                     <select name="octave_description" id="octave_description" class="form-control">
@@ -124,14 +124,14 @@
                         <option value="none">None</option>
                         <option value="number">Number (4 / 5)</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="octave_position">Octave position</label>
                     <select name="octave_position" id="octave_position" class="form-control">
                         <option value="before" selected>Before pitch</option>
                         <option value="after">After pitch</option>
                     </select>
-                    <br/><br/>
+                    <br/>
 
                     <label for="octave_announcement">Octave announcement</label>
                     <select name="octave_announcement" id="octave_announcement" class="form-control">
@@ -140,10 +140,10 @@
                         <option value="firstNote">First note of section</option>
                         <option value="onChange" selected>On change</option>
                     </select>
-                    <br/><br/>
+                    <br/>
                 </div>
 
-                <h3>Coloured output:</h3>
+                <h2 class="bold">Coloured output:</h2>
                 <p class="lead">Set the text colour or background colour of parts of the description to use colours.</p>
                 <div class="form-group">
                     <label for="colour_position">Colour position</label>
@@ -176,7 +176,7 @@
                 </div>
 
             </form>
+        
         </div>
     </div>
-
 {% endblock content %}

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -5,68 +5,86 @@
 {% block noindex %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-    <h1>Summary:</h1>
-    <p class="lead">Right hand: {{summary_right_hand}}</p>
-    <p class="lead">Left hand: {{summary_left_hand}}</p>
-    
-    <h1>Repetition:</h1>
-    <p class="lead">Right hand: {{repetition_right_hand}}</p>
-    <p class="lead">Left hand: {{repetition_left_hand}}</p>
-    
-    <h1>Options</h1>
-    <p class="lead">Select which parts and how many bars at a time you would like.</p>
 
-    <div class="row text-left">
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger" role="alert">
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+            {{ form.non_field_errors }}
+        </div>
+    {% endif %}
+
+    {% if form.errors %}
+        <div class="alert alert-danger" role="alert">
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+            {{ form.errors }}
+        </div>
+    {% endif %}
+
+    <h1>Detected features:</h1>
+    <div class="row text-left lead">
         <div class="col-md-6 col-md-offset-3">
-            <h3>Detected features:</h3>
             <ul class="list-unstyled">
-                <li>{{ title }} by {{ composer }}</li>
-                <li>{{ instruments|length }} instrument{{ instruments|length|pluralize }}:
-                    {% for instrument in instruments %}
-    {% if forloop.first %}{% else %}
-        {% if forloop.last %} and {% else %}, {% endif %}
-    {% endif %}{{instrument}}
-{% endfor %} </li>
-                <li>Time signature of {{ time_signature }}</li>
-                <li>Key signature of {{ key_signature }}</li>
-                <li>Tempo: {{ tempo }}</li>
-                <li>{{ number_of_bars }} bars</li>
+                <li>{{ score_info.title }} by {{ score_info.composer }}</li>
+                <li>{{ score_info.instruments|length }} instrument{{ score_info.instruments|length|pluralize }}:
+                {% for instrument in score_info.instruments %}
+                    {% if forloop.first %}{% else %}
+                        {% if forloop.last %} and {% else %}, {% endif %}
+                    {% endif %}{{instrument}}
+                {% endfor %} </li>
+                <li>Time signature of {{ score_info.time_signature }}</li>
+                <li>Key signature of {{ score_info.key_signature }}</li>
+                <li>Tempo: {{ score_info.tempo }}</li>
+                <li>{{ score_info.number_of_bars }} bars</li>
             </ul>
         </div>
     </div>
 
+    <h1>Summary:</h1>
     <div class="row text-left">
         <div class="col-md-6 col-md-offset-3">
-            <h3>Options:</h3>
-
-        {% if form.non_field_errors %}
-        <div class="alert alert-danger" role="alert">
-        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            {{ form.non_field_errors }}
+            <p class="lead">Right hand: {{score_info.summary_right_hand}}</p>
+            <p class="lead">Left hand: {{score_info.summary_left_hand}}</p>
         </div>
-        {% endif %}
-
-
-        {% if form.errors %}
-        <div class="alert alert-danger" role="alert">
-        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            {{ form.errors }}
+    </div>
+    
+    <h1>Repetition:</h1>
+    <div class="row text-left">
+        <div class="col-md-6 col-md-offset-3">        <p class="lead">Right hand: {{score_info.repetition_right_hand}}</p>
+            <p class="lead">Left hand: {{score_info.repetition_left_hand}}</p>
         </div>
-        {% endif %}
-
+    </div>
+    <h1>Options</h1>
+    
+    <div class="row text-left">
+        <div class="col-md-6 col-md-offset-3">
+            
             <form class="form-horizontal" method="post">
                 {% csrf_token %}
-                <div class="form-group">
-                    <p>Selected instruments:</p>
-
-                    {% for instrument in instruments %}
+                
+                <div id="" class="form-group">
                     <div class="checkbox">
-                        <label for="instrument_{{ forloop.counter }}">
-                            <input type="checkbox" id="instrument_{{ forloop.counter }}" value="checked" checked="checked"
-                                   aria-label="{{ instrument }}">
-                            {{ instrument }}
-                        </label>
+                        <input type="checkbox" name="chk_playAll" id="chk_playAll" value="checked" checked="checked" aria-label="Play all parts"/>
+                        <label for="chk_playAll">Play all parts</label>
                     </div>
+                    <div class="checkbox">
+                        <input type="checkbox" name="chk_playSelected" id="chk_playSelected" value="checked" checked="checked" aria-label="Play all selected parts together"/>
+                        <label for="chk_playSelected">Play all selected parts together</label>
+                    </div>
+                    <div class="checkbox">
+                        <input type="checkbox" name="chk_playUnselected" id="chk_playUnselected" value="checked" checked="checked" aria-label="Play all not selected parts together"/>
+                        <label for="chk_playUnselected">Play all not selected parts together</label>
+                    </div>
+                </div>
+    
+                <h3>Selected instruments:</h3>
+                <div id="" class="form-group">                    
+                    {% for instrument in score_info.instruments %}
+                        <div class="checkbox">
+                            <input type="checkbox" name="instruments" id="instrument_{{ forloop.counter }}" value="{{ forloop.counter }}" checked="checked" aria-label="{{ instrument }}">
+                            <label for="instrument_{{ forloop.counter }}">
+                                {{ instrument }}
+                            </label>
+                        </div>
                     {% endfor %}
                 </div>
                 <div class="form-group">

--- a/talkingscoresapp/templates/options.html
+++ b/talkingscoresapp/templates/options.html
@@ -61,10 +61,11 @@
             <form class="form-horizontal" method="post">
                 {% csrf_token %}
                 
+                <h3>Play parts:</h3>
                 <div id="" class="form-group">
                     <div class="checkbox">
-                        <input type="checkbox" name="chk_playAll" id="chk_playAll" value="checked" checked="checked" aria-label="Play all parts"/>
-                        <label for="chk_playAll">Play all parts</label>
+                        <input type="checkbox" name="chk_playAll" id="chk_playAll" value="checked" checked="checked" aria-label="Play all parts together"/>
+                        <label for="chk_playAll">Play all parts together</label>
                     </div>
                     <div class="checkbox">
                         <input type="checkbox" name="chk_playSelected" id="chk_playSelected" value="checked" checked="checked" aria-label="Play all selected parts together"/>
@@ -87,6 +88,8 @@
                         </div>
                     {% endfor %}
                 </div>
+
+                <h3>Description:</h3>
                 <div class="form-group">
                     <label for="bars_at_a_time">Bars at a time</label>
                     <select name="bars_at_a_time" id="bars_at_a_time" class="form-control">
@@ -95,14 +98,95 @@
                         <option>4</option>
                         <option>8</option>
                     </select>
+                    <br/><br/>
 
+                    <label for="pitch_description">Pitch description</label>
+                    <select name="pitch_description" id="pitch_description" class="form-control">
+                        <option value="figureNotes">Figure Notes (red / brown)</option>
+                        <option value="noteName" selected>Note names (C / D)</option>
+                        <option value="none">None</option>
+                    </select>
+                    No pitch description might be of interest when using Figure Note coloured output.
+                    <br/><br/>
+
+                    <label for="rhythm_description">Rhythm description</label>
+                    <select name="rhythm_description" id="rhythm_description" class="form-control">
+                        <option value="american">American (quarter note etc)</option>
+                        <option value="british" selected>British (crotchet etc)</option>
+                        <option value="none">None</option>
+                    </select>
+                    <br/><br/>
+
+                    <label for="dot_position">Position of dot in dotted rhythms</label>
+                    <select name="dot_position" id="dot_position" class="form-control">
+                        <option value="before" selected>Before rhythm</option>
+                        <option value="after">After rhythm</option>
+                    </select>
+                    <br/><br/>
+
+                    <label for="rhythm_announcement">Rhythm announcement</label>
+                    <select name="rhythm_announcement" id="rhythm_announcement" class="form-control">
+                        <option value="everyNote">Every note</option>
+                        <option value="onChange" selected>On change</option>
+                    </select>
+                    <br/><br/>
+
+                    <label for="octave_description">Octave description</label>
+                    <select name="octave_description" id="octave_description" class="form-control">
+                        <option value="figureNotes">Figure Notes (circle / triangle)</option>
+                        <option value="name" selected>Name (mid / high)</option>
+                        <option value="none">None</option>
+                        <option value="number">Number (4 / 5)</option>
+                    </select>
+                    <br/><br/>
+
+                    <label for="octave_position">Octave position</label>
+                    <select name="octave_position" id="octave_position" class="form-control">
+                        <option value="before" selected>Before pitch</option>
+                        <option value="after">After pitch</option>
+                    </select>
+                    <br/><br/>
+
+                    <label for="octave_announcement">Octave announcement</label>
+                    <select name="octave_announcement" id="octave_announcement" class="form-control">
+                        <option value="brailleRules">Braille rules</option>
+                        <option value="everyNote">Every note</option>
+                        <option value="firstNote">First note of section</option>
+                        <option value="onChange" selected>On change</option>
+                    </select>
+                    <br/><br/>
                 </div>
+
+                <h3>Coloured output (Figure Notes):</h3>
+                <div class="form-group">
+                    <label for="colour_position">Colour position</label>
+                    <select name="colour_position" id="colour_position" class="form-control">
+                        <option value="none" selected>None</option>
+                        <option value="background">Background</option>
+                        <option value="text">Text</option>
+                    </select>
+                    <br/>
+
+                    <div class="checkbox">
+                        <input type="checkbox" name="chk_colourPitch" id="chk_colourPitch" value="checked" aria-label="Colour pitch description"/>
+                        <label for="chk_colourPitch">Colour pitch description</label>
+                    </div>
+                    <div class="checkbox">
+                        <input type="checkbox" name="chk_colourRhythm" id="chk_colourRhythm" value="checked" aria-label="Colour rhythm description"/>
+                        <label for="chk_colourRhythm">Colour rhythm description</label>
+                    </div>
+                    <div class="checkbox">
+                        <input type="checkbox" name="chk_colourOctave" id="chk_colourOctave" value="checked"  aria-label="Colour octave description"/>
+                        <label for="chk_colourOctave">Colour octave description</label>
+                    </div>
+                </div>
+                <br/>
+
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-6">
                         <button type="submit" class="btn btn-primary btn-lg">Generate Talking Score</button>
                     </div>
                 </div>
-
 
             </form>
         </div>

--- a/talkingscoresapp/templates/privacy-policy.html
+++ b/talkingscoresapp/templates/privacy-policy.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Privacy Policy - Talking Scores (Beta){% endblock %}
 {% block meta-description %}Privacy policy for Talking Scores - an open source project to convert MusicXML files to a spoken representation.{% endblock %}

--- a/talkingscoresapp/templates/privacy-policy.html
+++ b/talkingscoresapp/templates/privacy-policy.html
@@ -7,52 +7,49 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <div class="col-md-8 col-md-offset-2 text-left">
+    <div class="col-md-11 mx-auto text-start">
 
         <h2>Privacy Policy</h2>
 
-        <p class="lead">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  The code running on this site will be fairly close to the code on Github - but there may be some differences due to testing / configuration etc. </p>
+        <p class="tsp">This is an <a href="https://github.com/bentimms/talkingscores" target="_blank">open source project</a> - currently undertaken by a very small team; working in our spare time.  The code running on this site will be fairly close to the code on Github - but there may be some differences due to testing / configuration etc. </p>
 
-        <p class="lead"><b>Communication</b><br/>
+        <p class="tsp"><b>Communication</b><br/>
             We welcome comments / suggestions / bug reports etc - it is encouraging to hear from users - thank you.  If you choose to contact us, we will try to reply in a timely manner.  We will most likely contact you again, some time later, when we have addressed the particular issue. <br/>
             We will not pass your contact details on to anyone else or use them for any other purpose.  <br/>
             However, we may: 
             <ul>
-                <li class="lead">Discuss your enquiry (not you, just your enquiry) with other individuals / organisations. </li>
-                <li class="lead">Publish your enquiry (again, not you, just your enquiry), or aspects of it - for example as part of a Frequently Asked Questions page.</li>
-                <li class="lead">Suggest other individuals / organisations / software that might be able to assist with your enquiry.  </li>
+                <li class="tsp">Discuss your enquiry (not you, just your enquiry) with other individuals / organisations. </li>
+                <li class="tsp">Publish your enquiry (again, not you, just your enquiry), or aspects of it - for example as part of a Frequently Asked Questions page.</li>
+                <li class="tsp">Suggest other individuals / organisations / software that might be able to assist with your enquiry.  </li>
             </ul>
         </p>
         
-        <p class="lead"><b>Uploaded files</b><br/>
+        <p class="tsp"><b>Uploaded files</b><br/>
             Any files you upload / send us will only be used to produce Talking Scores.  <br/>
             Your musicxml file (and the talking scores output) will never be shared with any third party.  <br/>
             However, your musicxml file (or the talking scores output) may be accessed by us - in order to resolve issues or during development / testing / maintenance.   
         </p>
 
-        <p class="lead"><b>Google Analytics</b><br/>
+        <p class="tsp"><b>Google Analytics</b><br/>
             This website uses Google Analytics to give us an idea of how many users the website has / how long they use it for / what pages they view etc. <br/>
             The HTML output of a Talking Score does not include Google Analytics code - thus the scores are not tracked.  This website uses robots.txt and noindex to inform search engines that completed scores should not be indexed.  
         </p>
 
-        <p class="lead"><b>Google Search Console</b><br/>
+        <p class="tsp"><b>Google Search Console</b><br/>
             This website uses Google Search Console to give us an idea of how it appears in searches on Google.</p>
             
-        <p class="lead"><b>Cookies</b><br/>
+        <p class="tsp"><b>Cookies</b><br/>
             This website uses the following cookies:
             <ul>
-                <li class="lead">'_ga', '_gid', '_gat_gtag_' - used by Google Analytics.</li>
-                <li class="lead">'csrftoken' - helps to prevent Cross Site Request Forgery.</li>
+                <li class="tsp">'_ga', '_gid', '_gat_gtag_' - used by Google Analytics.</li>
+                <li class="tsp">'csrftoken' - helps to prevent Cross Site Request Forgery.</li>
             </ul>
         </p>
 
-        <p class="lead"><b>Security</b><br/>
-            We will endeavour to keep this website and its related communications secure.  We do this by considering the tools and processes we use, along with the libraries we build upon and code we write.  <br/>
-            But we cannot guarantee that the files you upload nor your communications with us will not be accessed by others - despite our best efforts.
+        <p class="tsp"><b>Security</b><br/>
+            We will endeavour to keep this website and its related communications secure.  We do this by considering the tools and processes we use, along with the libraries we build upon and code we write.  <br/> <br/>
+            But despite our best efforts, we cannot guarantee that the files you upload nor your communications with us will not be accessed by others.
         </p>
-        
-        
-        
         
     </div>
 

--- a/talkingscoresapp/templates/processing.html
+++ b/talkingscoresapp/templates/processing.html
@@ -7,7 +7,7 @@
 {% block content %}
     <h1>Talking Scores Beta</h1>
 
-    <div class="col-md-8 col-md-offset-2 text-left">
+    <div class="col-md-11 mx-auto text-start">
 
         <h4>Processing score... this may take a minute or two while all the files are generated. Please
             be patient and don't close or refresh this page.</h4>

--- a/talkingscoresapp/templates/processing.html
+++ b/talkingscoresapp/templates/processing.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Processing Score - Talking Scores (Beta){% endblock %}
 {% block noindex %}<meta name="robots" content="noindex" />{% endblock %}

--- a/talkingscoresapp/templates/robots.txt
+++ b/talkingscoresapp/templates/robots.txt
@@ -2,5 +2,4 @@ User-agent: *
 Disallow: /score_options/
 Disallow: /process/
 Disallow: /score/
-Disallow: /midis/
 

--- a/talkingscoresapp/templates/score.html
+++ b/talkingscoresapp/templates/score.html
@@ -1,5 +1,5 @@
 {% extends "base_site.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <h1>Talking Scores Beta</h1>

--- a/talkingscoresapp/templates/sitemap.xml
+++ b/talkingscoresapp/templates/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.talkingscores.org</loc>
+    <loc>https://www.talkingscores.org/change-log</loc>
+    <loc>https://www.talkingscores.org/contact-us</loc>
+  </url>
+</urlset>

--- a/talkingscoresapp/urls.py
+++ b/talkingscoresapp/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('oops/<id>/<filename>', views.error, name='error'),
     path('midis/<id>/<filename>',views.midi, name="midi" ),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), ),
+    path("sitemap.xml", TemplateView.as_view(template_name="sitemap.xml", content_type="text/xml"), ),
 ]

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -9,6 +9,8 @@ import sys
 import json
 import logging, logging.handlers, logging.config
 from talkingscores.settings import BASE_DIR, MEDIA_ROOT
+from lib.midiHandler import *
+
 from talkingscoreslib import Music21TalkingScore
 
 from talkingscoresapp.models import TSScore, TSScoreState
@@ -101,16 +103,11 @@ def score(request, id, filename):
     return HttpResponse(template.render(context, request))
 
 # View for midi files to serve with CORS header
+# use GET query string to generate the correct midi file
 def midi(request, id, filename):
-    type = request.GET.get('type')
-    start_measure = request.GET.get('starMeasure')
-    end_measure = request.GET.get('endMeasure')
-    instrument = request.GET.get('instrument')
-    part = request.GET.get('part')
-    print ("GET type = " + str(type))
-    print ("GET instrument = " + str(instrument))
-    print ("GET part = " + str(part))
-    fr = FileResponse(open("staticfiles/data/" + id + "/" + filename, "rb"))
+    mh = MidiHandler(request.GET, id, filename)
+    midiname = mh.get_or_make_midi_file()
+    fr = FileResponse(open("staticfiles/data/" + id + "/" + midiname, "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
     return fr
 

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -102,6 +102,14 @@ def score(request, id, filename):
 
 # View for midi files to serve with CORS header
 def midi(request, id, filename):
+    type = request.GET.get('type')
+    start_measure = request.GET.get('starMeasure')
+    end_measure = request.GET.get('endMeasure')
+    instrument = request.GET.get('instrument')
+    part = request.GET.get('part')
+    print ("GET type = " + str(type))
+    print ("GET instrument = " + str(instrument))
+    print ("GET part = " + str(part))
     fr = FileResponse(open("staticfiles/data/" + id + "/" + filename, "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
     return fr

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -39,6 +39,18 @@ class TalkingScoreGenerationOptionsForm(forms.Form):
     bars_at_a_time = forms.ChoiceField(choices=(('1', 1), ('2', 2), ('4', 4), ('8', 8)), initial=4,
         label="Bars at a time")
 
+    pitch_description = forms.CharField(widget=forms.Select, required=False,)
+    rhythm_description = forms.CharField(widget=forms.Select, required=False,)
+    dot_position = forms.CharField(widget=forms.Select, required=False,)
+    rhythm_announcement = forms.CharField(widget=forms.Select, required=False,)
+    octave_description = forms.CharField(widget=forms.Select, required=False,)
+    octave_position = forms.CharField(widget=forms.Select, required=False,)
+    octave_announcement = forms.CharField(widget=forms.Select, required=False,)
+    
+    colour_position = forms.CharField(widget=forms.Select, required=False,)
+    chk_colourPitch = forms.BooleanField(required=False)
+    chk_colourRhythm = forms.BooleanField(required=False)
+    chk_colourOctave = forms.BooleanField(required=False)
 
 class NotifyEmailForm(forms.Form):
     notify_email = forms.EmailField()
@@ -154,6 +166,19 @@ def options(request, id, filename):
             options["play_selected"] = form.cleaned_data["chk_playSelected"]
             options["play_unselected"] = form.cleaned_data["chk_playUnselected"]
             options["instruments"] = instruments
+            
+            options["pitch_description"] = form.cleaned_data["pitch_description"]
+            options["rhythm_description"] = form.cleaned_data["rhythm_description"]
+            options["dot_position"] = form.cleaned_data["dot_position"]
+            options["rhythm_announcement"] = form.cleaned_data["rhythm_announcement"]
+            options["octave_description"] = form.cleaned_data["octave_description"]
+            options["octave_position"] = form.cleaned_data["octave_position"]
+            options["octave_announcement"] = form.cleaned_data["octave_announcement"]
+            
+            options["colour_position"] = form.cleaned_data["colour_position"]
+            options["colour_pitch"] = form.cleaned_data["chk_colourPitch"]
+            options["colour_rhythm"] = form.cleaned_data["chk_colourRhythm"]
+            options["colour_octave"] = form.cleaned_data["chk_colourOctave"]
             
             with open(options_path, "w") as options_fh:
                 json.dump(options, options_fh)

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -202,7 +202,7 @@ def options(request, id, filename):
             logger.warn("Invalid form..." + str(form.errors))
             print ( str(form.errors))
             if form.cleaned_data["instruments"]=='':
-                form.add_error("instruments", "Please select at least instrument to describe...")
+                form.add_error("instruments", "Please select at least one instrument to describe...")
             
     else:
         form = TalkingScoreGenerationOptionsForm()

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -107,7 +107,7 @@ def score(request, id, filename):
 def midi(request, id, filename):
     mh = MidiHandler(request.GET, id, filename)
     midiname = mh.get_or_make_midi_file()
-    fr = FileResponse(open("staticfiles/data/" + id + "/" + midiname, "rb"))
+    fr = FileResponse(open(BASE_DIR+"/staticfiles/data/" + id + "/" + midiname, "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
     return fr
 

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -112,7 +112,7 @@ def score(request, id, filename):
 def midi(request, id, filename):
     mh = MidiHandler(request.GET, id, filename)
     midiname = mh.get_or_make_midi_file()
-    fr = FileResponse(open(BASE_DIR+"/staticfiles/data/" + id + "/" + midiname, "rb"))
+    fr = FileResponse(open(os.path.join(BASE_DIR, "staticfiles", "data", id, midiname), "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
     fr['X-Robots-Tag'] = "noindex"
     return fr

--- a/talkingscoresapp/views.py
+++ b/talkingscoresapp/views.py
@@ -109,6 +109,7 @@ def midi(request, id, filename):
     midiname = mh.get_or_make_midi_file()
     fr = FileResponse(open(BASE_DIR+"/staticfiles/data/" + id + "/" + midiname, "rb"))
     fr['Access-Control-Allow-Origin'] = '*'
+    fr['X-Robots-Tag'] = "noindex"
     return fr
 
 # View for a particular score


### PR DESCRIPTION
It can now generate talking scores for scores with multiple instruments / parts!  

Create midi files for the select instruments.  If an instrument has multiple parts - a midi file is created for each individual part and all parts together.  Option to create midi file for all instruments played together / just selected / just unselected instruments.  

Add a click track to the midi files and change the speed; whilst following time signature and tempo changes - hopefully!  

The midi files are now generated on demand as opposed to with the talking score due to the number of files ie 18 files for each segment of a piano score.  

Added options for pitch / rhythm names / dot position etc.

The description is improving - but still more to do.  

It can now describe beat fractions ie beat 1 - dotted crotchet, beat 2.5 quaver - as opposed to saying the quaver was on beat 2.  It still groups notes into the same beat - it doesn't treat semiquavers as beat 1, 1.25, 1.5, 1.75...

Imrpoved summarisation - includes time signatures / key signatures / tempo changes. 

Repetition is announced within the score eg "Bars 29 through 32 were first used at 1 and lately used at 9".   Ie the first time a section was used along with the most recent time.

Significant speed improvements - over twice as fast in some scores.  This speed increase was after we started generating midi files on demand ie the improvement is just in generating the talking score - not by simply skipping all the midi files!  

Files with the same hash can be uploaded and it will prepend "-ver2" - to "-ver9" on the end.  

Bug fixes.  